### PR TITLE
Refactor createCircuitWebWorkerformat for improved initialization

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,26 +1,33 @@
-import type { AnyCircuitElement } from "circuit-json"
-import * as Comlink from "comlink"
-import type {
-  InternalWebWorkerApi,
-  WebWorkerConfiguration,
-  CircuitWebWorker,
-} from "./shared/types"
-
-export const createCircuitWebWorker = async (
-  configuration: Partial<WebWorkerConfiguration>,
-): Promise<CircuitWebWorker> => {
-  // TODO implement
-  const webWorker = Comlink.wrap<InternalWebWorkerApi>(
-    new Worker(
-      configuration.webWorkerUrl ??
-        "https://unpkg.com/@tscircuit/eval-webworker/dist/webworker/index.js",
-    ),
-  )
-  if (configuration.snippetsApiBaseUrl) {
-    await webWorker.setSnippetsApiBaseUrl(configuration.snippetsApiBaseUrl)
-  }
-
-  // TODO set up listeners to track render state
-
-  return webWorker as any
-}
+import type { AnyCircuitElement } from "circuit-json"                                                          
+import * as Comlink from "comlink"                                                                             
+import type {                                                                                                  
+  InternalWebWorkerApi,                                                                                        
+  WebWorkerConfiguration,                                                                                      
+  CircuitWebWorker,                                                                                            
+} from "./shared/types"                                                                                        
+                                                                                                                
+export const createCircuitWebWorker = (                                                                        
+  configuration: Partial<WebWorkerConfiguration>,                                                              
+): CircuitWebWorker => {    
+  // TODO implement                                                                                   
+ const webWorker = Comlink.wrap<InternalWebWorkerApi>(                                                        
+    new Worker(                                                                                                
+      configuration.webWorkerUrl ??                                                                            
+        "https://unpkg.com/@tscircuit/eval-webworker/dist/webworker/index.js",                                 
+    ),                                                                                                         
+  )                                                                                                            
+                                                                                                               
+  // Return the wrapped worker with the correct interface                                                      
+  return {                                                                                                     
+    execute: async (code: string) => {                                                                         
+      if (configuration.snippetsApiBaseUrl) {                                                                  
+        await webWorker.setSnippetsApiBaseUrl(configuration.snippetsApiBaseUrl)                                
+      }                                                                                                        
+      return webWorker.execute(code)                                                                           
+    },         
+   // TODO set up listeners to track render state
+    renderUntilSettled: () => webWorker.renderUntilSettled(),                                                  
+    getCircuitJson: () => webWorker.getCircuitJson(),                                                          
+  }                                                                                                            
+}                                                                                                              
+                                                                                                                


### PR DESCRIPTION
Issue: #4 

I was unable to run test in this repo:

<img width="879" alt="image" src="https://github.com/user-attachments/assets/b60d5b5a-133d-4a91-9c09-e819eff64813">


Tried to fix it, changes:
- Removed async from the initialization function.
- Properly typed the return value acc to CircuitWebWorker interface.

<img width="427" alt="image" src="https://github.com/user-attachments/assets/68d1e84f-8203-4330-a42b-65cccf2229f1">

@seveibar I am not sure if these changes are required/desirable or i missed something in setting up the project.
Please do let me know