### PR TITLE
fix: manual-edits.json import error

### DIFF
--- a/lib/worker.ts
+++ b/lib/worker.ts
@@ -1,4 +1,3 @@
-import type { AnyCircuitElement } from "circuit-json"
 import * as Comlink from "comlink"
 export * from "./utils/index"
 import type {

--- a/tests/manual-edits.test.tsx
+++ b/tests/manual-edits.test.tsx
@@ -1,0 +1,114 @@
+import { expect, test } from "bun:test"
+import { createCircuitWebWorker } from "lib/index"
+import type { PcbComponent, SourceComponentBase } from "circuit-json"
+
+const example1 = {
+  entrypoint: "entrypoint.tsx",
+  fsMap: {
+    "entrypoint.tsx": `
+      const manualEdits = {
+        pcb_placements: [
+          {
+            selector: "R1",
+            center: {
+              x: 5,
+              y: 5
+            },
+            relative_to: "group_center",
+          }
+        ],
+        edit_events: [],
+        manual_trace_hints: []
+      };
+      
+      circuit.add(
+      <board width="20mm" height="20mm" 
+        manualEdits={manualEdits}
+      >
+        <resistor name="R1" resistance="10k" footprint="0402" />
+      </board>)
+    `,
+  },
+}
+
+const example2 = {
+  entrypoint: "entrypoint.tsx",
+  fsMap: {
+    "entrypoint.tsx": `
+      import manualEdits from "./manual-edits.json"
+      circuit.add(<board width="20mm" height="20mm" manualEdits={manualEdits}><resistor name="R1" resistance="10k" footprint="0402" /></board>)
+    `,
+    "manual-edits.json": `
+      {
+        "pcb_placements": [
+          {
+            "selector": "R1",
+            "center": {
+              "x": 5,
+              "y": 5
+            },
+            "relative_to": "group_center"
+          }
+        ],
+        "edit_events": [],
+        "manual_trace_hints": []
+      }
+    `,
+  },
+}
+
+test("example1: Manual edits in entrypoint.tsx file", async () => {
+  const circuitWebWorker = await createCircuitWebWorker({
+    webWorkerUrl: new URL("../webworker/index.ts", import.meta.url),
+  })
+
+  await circuitWebWorker.executeWithFsMap({
+    fsMap: example1.fsMap,
+    entrypoint: example1.entrypoint,
+  })
+
+  await circuitWebWorker.renderUntilSettled()
+
+  const circuitJson = await circuitWebWorker.getCircuitJson()
+
+  const R1 = circuitJson.find(
+    (el) => el.type === "source_component" && el.name === "R1",
+  ) as SourceComponentBase
+
+  const pcb_component = circuitJson.find(
+    (el: any) =>
+      el.type === "pcb_component" &&
+      el.source_component_id === R1?.source_component_id,
+  ) as PcbComponent
+
+  expect(pcb_component.center.x).toBe(5)
+  expect(pcb_component.center.y).toBe(5)
+})
+
+test("example2: Manual edits in manual-edits.json file", async () => {
+  const circuitWebWorker = await createCircuitWebWorker({
+    webWorkerUrl: new URL("../webworker/index.ts", import.meta.url),
+  })
+
+  await circuitWebWorker.executeWithFsMap({
+    fsMap: example2.fsMap,
+    entrypoint: example2.entrypoint,
+  })
+
+  await circuitWebWorker.renderUntilSettled()
+
+  const circuitJson = await circuitWebWorker.getCircuitJson()
+
+  const R1 = circuitJson.find(
+    (el) => el.type === "source_component" && el.name === "R1",
+  ) as SourceComponentBase
+
+  const pcb_component = circuitJson.find(
+    (el: any) =>
+      el.type === "pcb_component" &&
+      el.source_component_id === R1?.source_component_id,
+  ) as PcbComponent
+
+  expect(pcb_component.center.x).toBe(5)
+  expect(pcb_component.center.y).toBe(5)
+})

--- a/webworker/import-local-file.ts
+++ b/webworker/import-local-file.ts
@@ -1,11 +1,10 @@
-import type { ExecutionContext } from "./execution-context"
-import { importEvalPath } from "./import-eval-path"
 import * as Babel from "@babel/standalone"
-import { evalCompiledJs } from "./eval-compiled-js"
-import { getImportsFromCode } from "lib/utils/get-imports-from-code"
-import { normalizeFilePath } from "lib/runner/normalizeFsMap"
 import { resolveFilePathOrThrow } from "lib/runner/resolveFilePath"
 import { dirname } from "lib/utils/dirname"
+import { getImportsFromCode } from "lib/utils/get-imports-from-code"
+import { evalCompiledJs } from "./eval-compiled-js"
+import type { ExecutionContext } from "./execution-context"
+import { importEvalPath } from "./import-eval-path"
 
 export const importLocalFile = async (
   importName: string,
@@ -20,7 +19,11 @@ export const importLocalFile = async (
   }
   const fileContent = fsMap[fsPath]
   if (fsPath.endsWith(".json")) {
-    preSuppliedImports[fsPath] = JSON.parse(fileContent)
+    const jsonData = JSON.parse(fileContent);
+    preSuppliedImports[fsPath] = {
+      __esModule: true,
+      default: jsonData
+    };
   } else if (fsPath.endsWith(".tsx") || fsPath.endsWith(".ts")) {
     const importNames = getImportsFromCode(fileContent)
 

--- a/webworker/import-local-file.ts
+++ b/webworker/import-local-file.ts
@@ -19,11 +19,11 @@ export const importLocalFile = async (
   }
   const fileContent = fsMap[fsPath]
   if (fsPath.endsWith(".json")) {
-    const jsonData = JSON.parse(fileContent);
+    const jsonData = JSON.parse(fileContent)
     preSuppliedImports[fsPath] = {
       __esModule: true,
-      default: jsonData
-    };
+      default: jsonData,
+    }
   } else if (fsPath.endsWith(".tsx") || fsPath.endsWith(".ts")) {
     const importNames = getImportsFromCode(fileContent)
 


### PR DESCRIPTION
Babel transforms this into code that checks for an __esModule property on the imported module to determine how to handle the default export