### PR TITLE
runTscircuitModule

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,22 @@ await circuitWebWorker.renderUntilSettled()
 const circuitJson = await circuitWebWorker.getCircuitJson()
 ```
 
+### 5. Running a Module Directly: `runTscircuitModule`
+
+If you want to quickly run a published tscircuit module by its name (e.g., from the tscircuit registry), you can use `runTscircuitModule`. This function handles the import and execution for you.
+
+```tsx
+import { runTscircuitModule } from "@tscircuit/eval"
+
+// Run a module by its full name
+const circuitJson = await runTscircuitModule("@tsci/seveibar.usb-c-flashlight")
+
+// Or use a shorthand (will be prefixed with "@tsci/")
+const circuitJsonShorthand = await runTscircuitModule("seveibar/usb-c-flashlight")
+
+console.log(circuitJson)
+```
+
 ## When to Use Which Approach
 
 **CircuitRunner (Direct Execution)**

--- a/biome.json
+++ b/biome.json
@@ -35,6 +35,7 @@
         "noUselessElse": "off",
         "noNonNullAssertion": "off",
         "useNumberNamespace": "off",
+        "noParameterAssign": "off",
         "useFilenamingConvention": {
           "level": "error",
           "options": {

--- a/lib/runner/index.ts
+++ b/lib/runner/index.ts
@@ -1,2 +1,3 @@
 export * from "./CircuitRunner"
 export * from "./runTscircuitCode"
+export * from "./runTscircuitModule"

--- a/lib/runner/runTscircuitModule.ts
+++ b/lib/runner/runTscircuitModule.ts
@@ -1,0 +1,11 @@
+import { runTscircuitCode } from "./runTscircuitCode"
+
+export const runTscircuitModule = async (module: string) => {
+  if (!module.startsWith("@")) {
+    module = `@tsci/${module.replace(/\//, ".")}`
+  }
+  const circuitJson = await runTscircuitCode({
+    "user-code.tsx": `export * from "${module}";`,
+  })
+  return circuitJson
+}

--- a/lib/runner/runTscircuitModule.ts
+++ b/lib/runner/runTscircuitModule.ts
@@ -5,7 +5,13 @@ export const runTscircuitModule = async (module: string) => {
     module = `@tsci/${module.replace(/\//, ".")}`
   }
   const circuitJson = await runTscircuitCode({
-    "user-code.tsx": `export * from "${module}";`,
+    // TODO handle exports that are not the default export by scanning
+    // otherExports for components
+    "user-code.tsx": `
+    import Module, * as otherExports from "${module}";
+
+    export default Module;
+    `,
   })
   return circuitJson
 }

--- a/lib/utils/get-imports-from-code.ts
+++ b/lib/utils/get-imports-from-code.ts
@@ -10,5 +10,13 @@ export const getImportsFromCode = (code: string): string[] => {
     imports.push(match[1])
   }
 
+  // Match re-exports
+  const reExportRegex = /^\s*export \* from\s+['"](.+?)['"];/gm
+  let reExportMatch: RegExpExecArray | null
+  // biome-ignore lint/suspicious/noAssignInExpressions: <explanation>
+  while ((reExportMatch = reExportRegex.exec(code)) !== null) {
+    imports.push(reExportMatch[1])
+  }
+
   return imports
 }

--- a/lib/utils/get-imports-from-code.ts
+++ b/lib/utils/get-imports-from-code.ts
@@ -11,7 +11,8 @@ export const getImportsFromCode = (code: string): string[] => {
   }
 
   // Match re-exports
-  const reExportRegex = /^\s*export \* from\s+['"](.+?)['"];/gm
+  const reExportRegex =
+    /^\s*export\s+(?:\*|(?:\{[\s\w,]+\}))\s+from\s+['"](.+?)['"]/gm
   let reExportMatch: RegExpExecArray | null
   // biome-ignore lint/suspicious/noAssignInExpressions: <explanation>
   while ((reExportMatch = reExportRegex.exec(code)) !== null) {

--- a/tests/example14-run-tscircuit-module.test.tsx
+++ b/tests/example14-run-tscircuit-module.test.tsx
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+import { runTscircuitModule } from "lib/runner"
+
+test(
+  "example14 runTscircuitModule",
+  async () => {
+    const circuitJson = await runTscircuitModule("seveibar/usb-c-flashlight")
+
+    expect(circuitJson).toBeDefined()
+
+    const sourceComponent = circuitJson.find(
+      (element) => element.type === "source_component",
+    )
+
+    expect(sourceComponent).toBeDefined()
+  },
+  { timeout: 15000 }, // Increased timeout for potential network request
+)

--- a/tests/example14-run-tscircuit-module.test.tsx
+++ b/tests/example14-run-tscircuit-module.test.tsx
@@ -4,7 +4,9 @@ import { runTscircuitModule } from "lib/runner"
 test(
   "example14 runTscircuitModule",
   async () => {
-    const circuitJson = await runTscircuitModule("seveibar/usb-c-flashlight")
+    const circuitJson = await runTscircuitModule(
+      "@tsci/seveibar.usb-c-flashlight",
+    )
 
     expect(circuitJson).toBeDefined()
 


### PR DESCRIPTION
### 5. Running a Module Directly: `runTscircuitModule`

If you want to quickly run a published tscircuit module by its name (e.g., from the tscircuit registry), you can use `runTscircuitModule`. This function handles the import and execution for you.

```tsx
import { runTscircuitModule } from "@tscircuit/eval"

// Run a module by its full name
const circuitJson = await runTscircuitModule("@tsci/seveibar.usb-c-flashlight")

// Or use a shorthand (will be prefixed with "@tsci/")
const circuitJsonShorthand = await runTscircuitModule("seveibar/usb-c-flashlight")

console.log(circuitJson)
```