### PR TITLE
ci: update GitHub Actions workflows to use latest versions

### DIFF
--- a/.github/workflows/bun-formatcheck.yml
+++ b/.github/workflows/bun-formatcheck.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 

--- a/.github/workflows/bun-pver-release.yml
+++ b/.github/workflows/bun-pver-release.yml
@@ -12,12 +12,12 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 

--- a/.github/workflows/bun-typecheck.yml
+++ b/.github/workflows/bun-typecheck.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
       

--- a/.github/workflows/update-tscircuit-core.yml
+++ b/.github/workflows/update-tscircuit-core.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v4
         
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         
       - name: Close existing PRs
         run: |


### PR DESCRIPTION
Update `actions/checkout` to v4 and `oven-sh/setup-bun` to v2 across all workflows to ensure compatibility and leverage the latest features and improvements.