### PR TITLE
Update core, switch to peer dep versions to get updated footprinter etc

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,13 @@
     "@babel/standalone": "^7.26.2",
     "@biomejs/biome": "^1.9.4",
     "@playwright/test": "^1.50.1",
+<<<<<<< Updated upstream
     "@tscircuit/core": "^0.0.395",
     "@tscircuit/math-utils": "^0.0.18",
+=======
+    "@tscircuit/core": "^0.0.398",
+    "@tscircuit/math-utils": "^0.0.15",
+>>>>>>> Stashed changes
     "@types/babel__standalone": "^7.1.9",
     "@types/bun": "latest",
     "@types/react": "^18.3.12",

--- a/package.json
+++ b/package.json
@@ -47,17 +47,12 @@
     "@babel/standalone": "^7.26.2",
     "@biomejs/biome": "^1.9.4",
     "@playwright/test": "^1.50.1",
-<<<<<<< Updated upstream
-    "@tscircuit/core": "^0.0.395",
     "@tscircuit/math-utils": "^0.0.18",
-=======
     "@tscircuit/core": "^0.0.398",
-    "@tscircuit/math-utils": "^0.0.15",
->>>>>>> Stashed changes
     "@types/babel__standalone": "^7.1.9",
     "@types/bun": "latest",
     "@types/react": "^18.3.12",
-    "circuit-json": "^0.0.169",
+    "circuit-json": "^0.0.170",
     "comlink": "^4.4.2",
     "jscad-fiber": "^0.0.79",
     "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@biomejs/biome": "^1.9.4",
     "@playwright/test": "^1.50.1",
     "@tscircuit/math-utils": "^0.0.18",
-    "@tscircuit/core": "^0.0.398",
+    "@tscircuit/core": "^0.0.399",
     "@types/babel__standalone": "^7.1.9",
     "@types/bun": "latest",
     "@types/react": "^18.3.12",


### PR DESCRIPTION
- **remove prompt benchmarks**
- **update deps**
- **update core to versions with fixed peer deps**
