### PR TITLE
Increase timeout for nine key keyboard test

### DIFF
--- a/tests/nine-keyboard-default-export.test.tsx
+++ b/tests/nine-keyboard-default-export.test.tsx
@@ -22,5 +22,6 @@ export default () => <NineKeyKeyboard />
 
     expect(someSourceElm).toBeDefined()
   },
-  { timeout: 10000 },
+  // Increase timeout because NineKeyKeyboard can take longer to initialize
+  { timeout: 45000 },
 )


### PR DESCRIPTION
## Summary
- bump NineKeyKeyboard test timeout from 10s to 45s

## Testing
- `bun test tests/nine-keyboard-default-export.test.tsx` *(fails: Import "@tsci/seveibar.nine-key-keyboard" not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841edc162a8832eae2252f7ea6b25fd