### PR TITLE
updated core

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@biomejs/biome": "^1.8.3",
     "@playwright/test": "^1.50.1",
     "@tscircuit/capacity-autorouter": "^0.0.67",
-    "@tscircuit/core": "^0.0.444",
+    "@tscircuit/core": "^0.0.453",
     "@tscircuit/math-utils": "^0.0.18",
     "@tscircuit/parts-engine": "^0.0.2",
     "@types/babel__standalone": "^7.1.9",
@@ -59,7 +59,7 @@
     "comlink": "^4.4.2",
     "jscad-fiber": "^0.0.79",
     "react": "^19.0.0",
-    "schematic-symbols": "^0.0.143",
+    "schematic-symbols": "^0.0.155",
     "tsup": "^8.2.4"
   },
   "peerDependencies": {

--- a/tests/nine-keyboard-default-export.test.tsx
+++ b/tests/nine-keyboard-default-export.test.tsx
@@ -22,5 +22,5 @@ export default () => <NineKeyKeyboard />
 
     expect(someSourceElm).toBeDefined()
   },
-  { timeout: 10000 },
+  { timeout: 40000 },
 )

--- a/tests/nine-keyboard-default-export.test.tsx
+++ b/tests/nine-keyboard-default-export.test.tsx
@@ -22,5 +22,5 @@ export default () => <NineKeyKeyboard />
 
     expect(someSourceElm).toBeDefined()
   },
-  { timeout: 50000 },
+  { timeout: 60000 },
 )

--- a/tests/nine-keyboard-default-export.test.tsx
+++ b/tests/nine-keyboard-default-export.test.tsx
@@ -22,5 +22,5 @@ export default () => <NineKeyKeyboard />
 
     expect(someSourceElm).toBeDefined()
   },
-  { timeout: 40000 },
+  { timeout: 50000 },
 )


### PR DESCRIPTION
+ increased timeout for the nine-keyboard-default-export test which prevented eval from auto updating core