### PR TITLE
Fix nested board detection

### DIFF
--- a/lib/runner/setupDefaultEntrypointIfNeeded.ts
+++ b/lib/runner/setupDefaultEntrypointIfNeeded.ts
@@ -53,8 +53,18 @@ export const setupDefaultEntrypointIfNeeded = (opts: {
         .map(([_, component]) => component)[0] || (() => null);`
       }
 
-      const element = <ComponentToRender ${opts.mainComponentProps ? `{...${JSON.stringify(opts.mainComponentProps, null, 2)}}` : ""} />;
-      const isBoard = React.isValidElement(element) && element.type === "board";
+      const props = ${opts.mainComponentProps ? JSON.stringify(opts.mainComponentProps, null, 2) : '{}'};
+      let element = <ComponentToRender {...props} />;
+      let isBoard = false;
+
+      try {
+        const evaluated =
+          typeof ComponentToRender === "function" ? ComponentToRender(props) : null;
+        if (React.isValidElement(evaluated) && evaluated.type === "board") {
+          element = evaluated;
+          isBoard = true;
+        }
+      } catch {}
 
       if (!circuit._getBoard()) {
         circuit.add(isBoard ? element : <board>{element}</board>);

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@biomejs/biome": "^1.8.3",
     "@playwright/test": "^1.50.1",
     "@tscircuit/capacity-autorouter": "^0.0.67",
-    "@tscircuit/core": "^0.0.463",
+    "@tscircuit/core": "^0.0.465",
     "@tscircuit/math-utils": "^0.0.18",
     "@tscircuit/parts-engine": "^0.0.2",
     "@types/babel__standalone": "^7.1.9",

--- a/tests/example5-event-recording.test.tsx
+++ b/tests/example5-event-recording.test.tsx
@@ -21,6 +21,9 @@ test("example5-event-recording", async () => {
 
   await circuitWebWorker.renderUntilSettled()
 
+  // Allow any pending events to be dispatched
+  await new Promise((resolve) => setTimeout(resolve, 0))
+
   expect(eventCount).toBeGreaterThan(0)
   const initialEventCount = eventCount
 

--- a/tests/imported-board.test.tsx
+++ b/tests/imported-board.test.tsx
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test"
+import { createCircuitWebWorker } from "lib/index"
+
+test("no extra board when board component is imported", async () => {
+  const circuitWebWorker = await createCircuitWebWorker({
+    webWorkerUrl: new URL("../webworker/entrypoint.ts", import.meta.url),
+  })
+
+  await circuitWebWorker.executeWithFsMap({
+    fsMap: {
+      "index.tsx": `
+        import BoardComponent from "./board.tsx"
+        circuit.add(<BoardComponent />)
+      `,
+      "board.tsx": `
+        import "@tscircuit/core"
+        export default () => (
+          <board width="10mm" height="10mm">
+            <resistor name="R1" resistance="1k" footprint="0402" />
+          </board>
+        )
+      `,
+    },
+    mainComponentPath: "index.tsx",
+  })
+
+  await circuitWebWorker.renderUntilSettled()
+
+  const circuitJson = await circuitWebWorker.getCircuitJson()
+  const boards = circuitJson.filter((el: any) => el.type === "pcb_board")
+  expect(boards).toHaveLength(1)
+
+  await circuitWebWorker.kill()
+})


### PR DESCRIPTION
## Summary
- update @tscircuit/core
- detect boards inside imported files
- avoid wrapping entrypoint when main file already adds to the circuit
- add regression test for imported board

## Testing
- `bun test tests/imported-board.test.tsx`
- `bun test` *(fails: kill method > should immediately terminate the worker)*

------
https://chatgpt.com/codex/tasks/task_e_684c1889fff48332a2ec74b0abbf4b3b