### PR TITLE
Allow CircuitRunner platform override

### DIFF
--- a/lib/runner/CircuitRunner.ts
+++ b/lib/runner/CircuitRunner.ts
@@ -3,6 +3,7 @@ import type {
   CircuitRunnerApi,
   CircuitRunnerConfiguration,
 } from "lib/shared/types"
+import type { PlatformConfig } from "@tscircuit/props"
 import { createExecutionContext } from "../../webworker/execution-context"
 import { normalizeFsMap } from "./normalizeFsMap"
 import type { RootCircuit } from "@tscircuit/core"
@@ -18,6 +19,10 @@ export class CircuitRunner implements CircuitRunnerApi {
     verbose: false,
   }
   _eventListeners: Record<string, ((...args: any[]) => void)[]> = {}
+
+  constructor(configuration: Partial<CircuitRunnerConfiguration> = {}) {
+    Object.assign(this._circuitRunnerConfiguration, configuration)
+  }
 
   async executeWithFsMap(ogOpts: {
     entrypoint?: string
@@ -42,6 +47,7 @@ export class CircuitRunner implements CircuitRunnerApi {
       this._circuitRunnerConfiguration,
       {
         name: opts.name,
+        platform: this._circuitRunnerConfiguration.platform,
       },
     )
     this._bindEventListeners(this._executionContext.circuit)
@@ -69,7 +75,10 @@ export class CircuitRunner implements CircuitRunnerApi {
 
     this._executionContext = createExecutionContext(
       this._circuitRunnerConfiguration,
-      opts,
+      {
+        ...opts,
+        platform: this._circuitRunnerConfiguration.platform,
+      },
     )
     this._bindEventListeners(this._executionContext.circuit)
     this._executionContext.fsMap["entrypoint.tsx"] = code
@@ -123,6 +132,10 @@ export class CircuitRunner implements CircuitRunnerApi {
 
   async setSnippetsApiBaseUrl(baseUrl: string) {
     this._circuitRunnerConfiguration.snippetsApiBaseUrl = baseUrl
+  }
+
+  async setPlatformConfig(platform: PlatformConfig) {
+    this._circuitRunnerConfiguration.platform = platform
   }
 
   private _bindEventListeners(circuit: RootCircuit) {

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -1,10 +1,12 @@
 import type { AnyCircuitElement } from "circuit-json"
 import type { RootCircuitEventName } from "@tscircuit/core"
+import type { PlatformConfig } from "@tscircuit/props"
 
 export interface CircuitRunnerConfiguration {
   snippetsApiBaseUrl: string
   cjsRegistryUrl: string
   verbose?: boolean
+  platform?: PlatformConfig
 }
 
 export interface WebWorkerConfiguration extends CircuitRunnerConfiguration {
@@ -34,6 +36,7 @@ export interface CircuitRunnerApi {
   renderUntilSettled: () => Promise<void>
   getCircuitJson: () => Promise<AnyCircuitElement[]>
   setSnippetsApiBaseUrl: (baseUrl: string) => Promise<void>
+  setPlatformConfig: (platform: PlatformConfig) => Promise<void>
   on: (event: RootCircuitEventName, callback: (...args: any[]) => void) => void
   clearEventListeners: () => void
   kill: () => Promise<void>

--- a/lib/worker.ts
+++ b/lib/worker.ts
@@ -64,6 +64,9 @@ export const createCircuitWebWorker = async (
   if (configuration.snippetsApiBaseUrl) {
     await comlinkWorker.setSnippetsApiBaseUrl(configuration.snippetsApiBaseUrl)
   }
+  if (configuration.platform) {
+    await comlinkWorker.setPlatformConfig(configuration.platform)
+  }
 
   let isTerminated = false
 

--- a/tests/platform-config.test.tsx
+++ b/tests/platform-config.test.tsx
@@ -1,0 +1,23 @@
+import { CircuitRunner } from "lib/runner/CircuitRunner"
+import { expect, test } from "bun:test"
+
+test("platform configuration is forwarded to RootCircuit", async () => {
+  const runner = new CircuitRunner({ platform: { pcbDisabled: true } })
+
+  await runner.execute(`
+    circuit.add(
+      <board width="10mm" height="10mm">
+        <resistor name="R1" resistance="1k" footprint="0402" />
+      </board>
+    )
+  `)
+
+  await runner.renderUntilSettled()
+  const circuit = (globalThis as any).__tscircuit_circuit
+  expect(circuit.platform?.pcbDisabled).toBe(true)
+
+  const circuitJson = await runner.getCircuitJson()
+  expect(circuitJson.length).toBeGreaterThan(0)
+
+  await runner.kill()
+})

--- a/webworker/entrypoint.ts
+++ b/webworker/entrypoint.ts
@@ -5,6 +5,7 @@ import type {
   WebWorkerConfiguration,
 } from "lib/shared/types"
 import * as React from "react"
+import type { PlatformConfig } from "@tscircuit/props"
 import {
   createExecutionContext,
   type ExecutionContext,
@@ -22,6 +23,7 @@ const circuitRunnerConfiguration: WebWorkerConfiguration = {
   snippetsApiBaseUrl: "https://registry-api.tscircuit.com",
   cjsRegistryUrl: "https://cjs.tscircuit.com",
   verbose: false,
+  platform: undefined,
 }
 
 const eventListeners: Record<string, ((...args: any[]) => void)[]> = {}
@@ -37,6 +39,9 @@ function bindEventListeners(circuit: RootCircuit) {
 const webWorkerApi = {
   setSnippetsApiBaseUrl: async (baseUrl: string) => {
     circuitRunnerConfiguration.snippetsApiBaseUrl = baseUrl
+  },
+  setPlatformConfig: async (platform: PlatformConfig) => {
+    circuitRunnerConfiguration.platform = platform
   },
 
   async executeWithFsMap(opts: {
@@ -58,6 +63,7 @@ const webWorkerApi = {
 
     executionContext = createExecutionContext(circuitRunnerConfiguration, {
       name: opts.name,
+      platform: circuitRunnerConfiguration.platform,
     })
     bindEventListeners(executionContext.circuit)
     executionContext.fsMap = normalizeFsMap(opts.fsMap)
@@ -77,7 +83,10 @@ const webWorkerApi = {
     if (circuitRunnerConfiguration.verbose) {
       console.log("[Worker] execute called with code length:", code.length)
     }
-    executionContext = createExecutionContext(circuitRunnerConfiguration, opts)
+    executionContext = createExecutionContext(circuitRunnerConfiguration, {
+      ...opts,
+      platform: circuitRunnerConfiguration.platform,
+    })
     bindEventListeners(executionContext.circuit)
     executionContext.fsMap["entrypoint.tsx"] = code
     ;(globalThis as any).__tscircuit_circuit = executionContext.circuit


### PR DESCRIPTION
## Summary
- make `CircuitRunnerConfiguration` accept an optional platform configuration
- forward `platform` into `createExecutionContext`
- send platform configuration to web workers
- expose `setPlatformConfig` on `CircuitRunner`
- test that custom platform config reaches `RootCircuit`

## Testing
- `bun test tests/platform-config.test.tsx`

------
https://chatgpt.com/codex/tasks/task_b_6857ad8c1d94832e9afe2ee9a3dcd052