### PR TITLE
Add getPossibleEntrypointComponentPaths util

### DIFF
--- a/lib/getPossibleEntrypointComponentPaths.ts
+++ b/lib/getPossibleEntrypointComponentPaths.ts
@@ -1,0 +1,42 @@
+import { normalizeFilePath } from "./runner/normalizeFsMap"
+
+export const getPossibleEntrypointComponentPaths = (
+  fsMap: Record<string, string>,
+): string[] => {
+  const normalizedFsMap: Record<string, string> = {}
+  for (const [path, content] of Object.entries(fsMap)) {
+    normalizedFsMap[normalizeFilePath(path)] = content
+  }
+
+  const possible = new Set<string>()
+
+  if ("tscircuit.config.json" in normalizedFsMap) {
+    try {
+      const config = JSON.parse(normalizedFsMap["tscircuit.config.json"])
+      if (typeof config.mainEntrypoint === "string") {
+        possible.add(normalizeFilePath(config.mainEntrypoint))
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+
+  if (normalizedFsMap["index.tsx"]) possible.add("index.tsx")
+  if (normalizedFsMap["index.ts"]) possible.add("index.ts")
+
+  const circuitFiles = Object.keys(normalizedFsMap).filter((k) =>
+    k.endsWith(".circuit.tsx"),
+  )
+  for (const file of circuitFiles) {
+    possible.add(file)
+  }
+
+  const tsxFiles = Object.keys(normalizedFsMap).filter((k) =>
+    k.endsWith(".tsx"),
+  )
+  if (tsxFiles.length === 1) {
+    possible.add(tsxFiles[0])
+  }
+
+  return Array.from(possible)
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,2 +1,3 @@
 export * from "./runner"
 export * from "./worker"
+export * from "./getPossibleEntrypointComponentPaths"

--- a/tests/getPossibleEntrypointComponentPaths.test.ts
+++ b/tests/getPossibleEntrypointComponentPaths.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test"
+import { getPossibleEntrypointComponentPaths } from "lib/getPossibleEntrypointComponentPaths"
+
+test("returns index.tsx if present", () => {
+  const paths = getPossibleEntrypointComponentPaths({
+    "index.tsx": "export default () => null",
+    "foo.tsx": "",
+  })
+  expect(paths).toContain("index.tsx")
+})
+
+test("returns *.circuit.tsx files", () => {
+  const paths = getPossibleEntrypointComponentPaths({
+    "a.circuit.tsx": "",
+    "b.circuit.tsx": "",
+  })
+  expect(paths).toEqual(
+    expect.arrayContaining(["a.circuit.tsx", "b.circuit.tsx"]),
+  )
+})
+
+test("returns mainEntrypoint from config", () => {
+  const paths = getPossibleEntrypointComponentPaths({
+    "tscircuit.config.json": '{"mainEntrypoint": "src/main.tsx"}',
+    "src/main.tsx": "",
+  })
+  expect(paths).toContain("src/main.tsx")
+})
+
+test("returns single tsx file if only one", () => {
+  const paths = getPossibleEntrypointComponentPaths({
+    "only.tsx": "",
+  })
+  expect(paths).toContain("only.tsx")
+})


### PR DESCRIPTION
## Summary
- expose `getPossibleEntrypointComponentPaths` for listing candidate circuit entrypoints
- test the new helper

## Testing
- `bun test tests/getPossibleEntrypointComponentPaths.test.ts`
- `bun run format`

------
https://chatgpt.com/codex/tasks/task_b_685b0b68e500832ea1851f708cb1da95