### PR TITLE
Improve error messages with source lines

### DIFF
--- a/lib/utils/addSourceLineToError.ts
+++ b/lib/utils/addSourceLineToError.ts
@@ -1,4 +1,5 @@
-import { SourceMapConsumer, RawSourceMap } from "source-map"
+import { SourceMapConsumer } from "source-map"
+import type { RawSourceMap } from "source-map"
 
 export async function addSourceLineToError(
   error: Error,

--- a/lib/utils/addSourceLineToError.ts
+++ b/lib/utils/addSourceLineToError.ts
@@ -1,0 +1,39 @@
+import { SourceMapConsumer, RawSourceMap } from "source-map"
+
+export async function addSourceLineToError(
+  error: Error,
+  fsMap: Record<string, string>,
+  sourceMaps?: Record<string, RawSourceMap>,
+) {
+  if (!error || typeof error !== "object") return
+  const stack = (error as any).stack as string | undefined
+  if (!stack) return
+
+  const escapeRegExp = (str: string) =>
+    str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+
+  for (const path of Object.keys(fsMap)) {
+    const regex = new RegExp(escapeRegExp(path) + ":(\\d+):(\\d+)")
+    const match = stack.match(regex)
+    if (match) {
+      const line = parseInt(match[1], 10)
+      let originalLine = line
+      if (sourceMaps && sourceMaps[path]) {
+        const consumer = await new SourceMapConsumer(sourceMaps[path])
+        const pos = consumer.originalPositionFor({ line: line - 6, column: 0 })
+        consumer.destroy()
+        if (pos && pos.line) {
+          originalLine = pos.line
+        }
+      }
+      const lines = fsMap[path].split(/\r?\n/)
+      const sourceLine = lines[originalLine - 1]
+      if (sourceLine !== undefined) {
+        error.message += `\n\n> ${path}:${originalLine}\n> ${sourceLine.trim()}`
+      } else {
+        error.message += `\n\n> ${path}:${originalLine}`
+      }
+      break
+    }
+  }
+}

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,1 +1,2 @@
 export * from "./get-imports-from-code"
+export * from "./addSourceLineToError"

--- a/tests/execution-error-line.test.tsx
+++ b/tests/execution-error-line.test.tsx
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test"
+import { createCircuitWebWorker } from "lib/index"
+
+// Ensure that when runtime errors occur, the offending line is included
+
+test("execution error includes source line", async () => {
+  const worker = await createCircuitWebWorker({
+    webWorkerUrl: new URL("../webworker/entrypoint.ts", import.meta.url),
+  })
+
+  await expect(
+    worker.executeWithFsMap({
+      entrypoint: "index.tsx",
+      fsMap: {
+        "index.tsx": `
+          circuit.add(<board width="10mm" height="10mm" />)
+          throw new Error("boom")
+        `,
+      },
+    }),
+  ).rejects.toThrow(/boom\n[\s\S]*index.tsx:3/)
+
+  await worker.kill()
+})

--- a/webworker/entrypoint.ts
+++ b/webworker/entrypoint.ts
@@ -14,6 +14,7 @@ import { importEvalPath } from "./import-eval-path"
 import { normalizeFsMap } from "../lib/runner/normalizeFsMap"
 import type { RootCircuit } from "@tscircuit/core"
 import { setupDefaultEntrypointIfNeeded } from "lib/runner/setupDefaultEntrypointIfNeeded"
+import { addSourceLineToError } from "lib/utils/addSourceLineToError"
 
 globalThis.React = React
 
@@ -76,7 +77,16 @@ const webWorkerApi = {
       entrypoint = `./${entrypoint}`
     }
 
-    await importEvalPath(entrypoint, executionContext)
+    try {
+      await importEvalPath(entrypoint, executionContext)
+    } catch (error: any) {
+      await addSourceLineToError(
+        error,
+        executionContext.fsMap,
+        executionContext.sourceMaps,
+      )
+      throw error
+    }
   },
 
   async execute(code: string, opts: { name?: string } = {}) {
@@ -91,7 +101,16 @@ const webWorkerApi = {
     executionContext.fsMap["entrypoint.tsx"] = code
     ;(globalThis as any).__tscircuit_circuit = executionContext.circuit
 
-    await importEvalPath("./entrypoint.tsx", executionContext)
+    try {
+      await importEvalPath("./entrypoint.tsx", executionContext)
+    } catch (error: any) {
+      await addSourceLineToError(
+        error,
+        executionContext.fsMap,
+        executionContext.sourceMaps,
+      )
+      throw error
+    }
   },
 
   on: (event: string, callback: (...args: any[]) => void) => {

--- a/webworker/eval-compiled-js.ts
+++ b/webworker/eval-compiled-js.ts
@@ -4,6 +4,7 @@ export function evalCompiledJs(
   compiledCode: string,
   preSuppliedImports: Record<string, any>,
   cwd?: string,
+  sourceUrl?: string,
 ) {
   ;(globalThis as any).__tscircuit_require = (name: string) => {
     const resolvedFilePath = resolveFilePath(name, preSuppliedImports, cwd)
@@ -56,6 +57,7 @@ export function evalCompiledJs(
   var module = { exports };
   var circuit = globalThis.__tscircuit_circuit;
   ${compiledCode};
+  //# sourceURL=${sourceUrl ?? "compiled.ts"}
   return module;`.trim()
   return Function(functionBody).call(globalThis)
 }

--- a/webworker/execution-context.ts
+++ b/webworker/execution-context.ts
@@ -11,6 +11,7 @@ export interface ExecutionContext extends WebWorkerConfiguration {
   fsMap: Record<string, string>
   entrypoint: string
   preSuppliedImports: Record<string, any>
+  sourceMaps: Record<string, any>
   circuit: RootCircuit
 }
 
@@ -45,6 +46,7 @@ export function createExecutionContext(
       // ignore type imports in getImportsFromCode
       "@tscircuit/props": {},
     },
+    sourceMaps: {},
     circuit,
     ...webWorkerConfiguration,
   }

--- a/webworker/import-snippet.ts
+++ b/webworker/import-snippet.ts
@@ -25,6 +25,8 @@ export async function importSnippet(
     preSuppliedImports[importName] = evalCompiledJs(
       cjs!,
       preSuppliedImports,
+      undefined,
+      importName,
     ).exports
   } catch (e) {
     console.error("Error importing snippet", e)


### PR DESCRIPTION
## Summary
- include original source line info when runtime errors occur
- maintain source maps in execution context
- annotate compiled code with sourceURL
- add tests for execution error source lines

## Testing
- `bun test tests/execution-error-line.test.tsx`
- `bun test tests` *(fails: network-dependent tests)*

------
https://chatgpt.com/codex/tasks/task_b_686499c3907c832eb2f9fdd7555b782b