### PR TITLE
Fix group board wrapper issue

### DIFF
--- a/lib/runner/setupDefaultEntrypointIfNeeded.ts
+++ b/lib/runner/setupDefaultEntrypointIfNeeded.ts
@@ -51,7 +51,8 @@ export const setupDefaultEntrypointIfNeeded = (opts: {
     const hasTsciImport =
       mainComponentCode.includes("@tsci/") ||
       mainComponentCode.includes('from "@tsci')
-    const shouldWrapInBoard = !hasExplicitBoard && !hasTsciImport
+    const hasGroup = mainComponentCode.includes("<group")
+    const shouldWrapInBoard = !hasExplicitBoard && !hasTsciImport && !hasGroup
 
     opts.fsMap[opts.entrypoint] = `
      import * as UserComponents from "./${opts.mainComponentPath}";

--- a/tests/group-wrapper.test.tsx
+++ b/tests/group-wrapper.test.tsx
@@ -1,0 +1,18 @@
+import { test, expect } from "bun:test"
+import { runTscircuitCode } from "lib/runner"
+
+test("group is not wrapped in board", async () => {
+  const circuitJson = await runTscircuitCode(`
+    export default () => (
+      <group name="G2">
+        <resistor name="R1" footprint="0402" resistance="10k" />
+        <capacitor name="C1" capacitance="10uF" footprint="0603" />
+      </group>
+    )
+  `)
+
+  const sourceGroups = circuitJson.filter((el) => el.type === "source_group")
+
+  expect(sourceGroups.length).toBe(1)
+  expect(sourceGroups[0].name).toBe("G2")
+})


### PR DESCRIPTION
## Summary
- avoid auto adding a board wrapper when the main component already contains a `<group>`
- add regression test to ensure only a single source_group is created

## Testing
- `bun test tests/group-wrapper.test.tsx`
- `bun test tests` *(fails: example14 runTscircuitModule, NineKeyKeyboard default export resolves and renders correctly, circuit-web-worker-events, example16-jlc-parts-engine with entrypoint, example16-jlc-parts-engine with mainComponentPath, example15 runTscircuitModule with props, virtual filesystem with components, example4-root-child-issue, parse tscircuit.config.js with mainEntrypoint, kill method > should immediately terminate the worker, example9-not-defined-component, circuitrunner1-readme-example)*

------
https://chatgpt.com/codex/tasks/task_b_6885ae74aaf08327a6ec6569a29e8324