### PR TITLE
refactor(runner): simplify default entrypoint setup by removing conditional board wrapping

### DIFF
--- a/lib/runner/setupDefaultEntrypointIfNeeded.ts
+++ b/lib/runner/setupDefaultEntrypointIfNeeded.ts
@@ -46,14 +46,6 @@ export const setupDefaultEntrypointIfNeeded = (opts: {
         `Main component path "${opts.mainComponentPath}" not found in fsMap. Available paths: ${Object.keys(opts.fsMap).join(", ")}`,
       )
     }
-
-    const hasExplicitBoard = mainComponentCode.includes("<board")
-    const hasTsciImport =
-      mainComponentCode.includes("@tsci/") ||
-      mainComponentCode.includes('from "@tsci')
-    const hasGroup = mainComponentCode.includes("<group")
-    const shouldWrapInBoard = !hasExplicitBoard && !hasTsciImport && !hasGroup
-
     opts.fsMap[opts.entrypoint] = `
      import * as UserComponents from "./${opts.mainComponentPath}";
           
@@ -76,18 +68,8 @@ export const setupDefaultEntrypointIfNeeded = (opts: {
                : ""
            }
 
-      circuit.add(
-        ${
-          shouldWrapInBoard
-            ? `
-          <board>
-            <ComponentToRender name="U1" ${opts.mainComponentProps ? `{...${JSON.stringify(opts.mainComponentProps, null, 2)}}` : ""} />
-          </board>
-        `
-            : `
-          <ComponentToRender ${opts.mainComponentProps ? `{...${JSON.stringify(opts.mainComponentProps, null, 2)}}` : ""} />
-        `
-        }
+      circuit.add(       
+          <ComponentToRender ${opts.mainComponentProps ? `{...${JSON.stringify(opts.mainComponentProps, null, 2)}}` : ""} /> 
       );
 `
   }

--- a/tests/example4-root-child-issue.test.tsx
+++ b/tests/example4-root-child-issue.test.tsx
@@ -11,23 +11,27 @@ const example4 = {
   },
 }
 
-test("example4-root-child-issue", async () => {
-  const circuitWebWorker = await createCircuitWebWorker({
-    webWorkerUrl: new URL("../webworker/entrypoint.ts", import.meta.url),
-  })
+test(
+  "example4-root-child-issue",
+  async () => {
+    const circuitWebWorker = await createCircuitWebWorker({
+      webWorkerUrl: new URL("../webworker/entrypoint.ts", import.meta.url),
+    })
 
-  await circuitWebWorker.executeWithFsMap({
-    fsMap: example4.fsMap,
-    entrypoint: example4.entrypoint,
-  })
+    await circuitWebWorker.executeWithFsMap({
+      fsMap: example4.fsMap,
+      entrypoint: example4.entrypoint,
+    })
 
-  await circuitWebWorker.renderUntilSettled()
+    await circuitWebWorker.renderUntilSettled()
 
-  const circuitJson = await circuitWebWorker.getCircuitJson()
+    const circuitJson = await circuitWebWorker.getCircuitJson()
 
-  const led = circuitJson.find((el: any) => el.name === "LED")
-  expect(led).toBeDefined()
-  expect(led?.type).toBe("source_component")
+    const led = circuitJson.find((el: any) => el.name === "LED")
+    expect(led).toBeDefined()
+    expect(led?.type).toBe("source_component")
 
-  await circuitWebWorker.kill()
-})
+    await circuitWebWorker.kill()
+  },
+  30 * 1000,
+)


### PR DESCRIPTION
fix #799 

The logic for wrapping components in a board was removed as it was deemed unnecessary. The component is now always rendered directly without conditional wrapping, simplifying the code and reducing complexity.