### PR TITLE
refactor: remove unused babel imports

### DIFF
--- a/webworker/import-eval-path.ts
+++ b/webworker/import-eval-path.ts
@@ -1,6 +1,5 @@
 import { evalCompiledJs } from "./eval-compiled-js"
 import type { ExecutionContext } from "./execution-context"
-import * as Babel from "@babel/standalone"
 import { importLocalFile } from "./import-local-file"
 import { importSnippet } from "./import-snippet"
 import { resolveFilePath } from "lib/runner/resolveFilePath"

--- a/webworker/import-snippet.ts
+++ b/webworker/import-snippet.ts
@@ -1,6 +1,5 @@
 import { evalCompiledJs } from "./eval-compiled-js"
 import type { ExecutionContext } from "./execution-context"
-import * as Babel from "@babel/standalone"
 import { importLocalFile } from "./import-local-file"
 import { importEvalPath } from "./import-eval-path"
 


### PR DESCRIPTION
## Summary
- remove unused babel imports in webworker utilities to slim worker bundle

## Testing
- `bun test tests/example1-readme-example.test.tsx`
- `bun test tests/example13-webworker-without-entrypoint.test.tsx`


------
https://chatgpt.com/codex/tasks/task_b_6896656ed210832ead8bce2fd51b30ac