### PR TITLE
feat: proxy fetch requests through parent

### DIFF
--- a/tests/fetch-override.test.ts
+++ b/tests/fetch-override.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "bun:test"
+import { createCircuitWebWorker } from "../lib"
+
+describe("fetch override", () => {
+  it("allows worker to fetch via parent and propagates errors", async () => {
+    const originalFetch = globalThis.fetch
+    const mockFetch = async (input: RequestInfo, init?: RequestInit) => {
+      if (typeof input === "string" && input.includes("cjs.tscircuit.com")) {
+        return new Response("module.exports = { default: 123 };", {
+          status: 200,
+        })
+      }
+      throw new Error("mock fail")
+    }
+    globalThis.fetch = mockFetch as any
+
+    const worker = await createCircuitWebWorker({
+      webWorkerUrl: new URL("../dist/webworker/entrypoint.js", import.meta.url)
+        .href,
+    })
+
+    const rawWorker: Worker = (worker as any).__rawWorker
+    const messages: any[] = []
+    rawWorker.addEventListener("message", (event) => {
+      if (event.data?.type === "fetch-error") messages.push(event.data)
+    })
+
+    await worker.execute(`
+import val from "@tsci/test.snippet";
+if (val !== 123) { throw new Error("snippet failed"); }
+fetch("https://fail.test").catch(e => {
+  postMessage({ type: "fetch-error", name: e.name, message: e.message });
+});
+`)
+
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(messages).toEqual([
+      { type: "fetch-error", name: "Error", message: "mock fail" },
+    ])
+
+    await worker.kill()
+    globalThis.fetch = originalFetch
+  })
+})

--- a/webworker/entrypoint.ts
+++ b/webworker/entrypoint.ts
@@ -14,8 +14,10 @@ import { importEvalPath } from "./import-eval-path"
 import { normalizeFsMap } from "../lib/runner/normalizeFsMap"
 import type { RootCircuit } from "@tscircuit/core"
 import { setupDefaultEntrypointIfNeeded } from "lib/runner/setupDefaultEntrypointIfNeeded"
+import { setupFetchProxy } from "./fetchProxy"
 
 globalThis.React = React
+setupFetchProxy()
 
 let executionContext: ExecutionContext | null = null
 

--- a/webworker/fetchProxy.ts
+++ b/webworker/fetchProxy.ts
@@ -1,0 +1,73 @@
+export const setupFetchProxy = () => {
+  const pendingRequests = new Map<
+    number,
+    { resolve: (value: Response) => void; reject: (reason: any) => void }
+  >()
+  let requestCounter = 0
+
+  function fetchProxy(
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> {
+    const requestId = ++requestCounter
+    return new Promise((resolve, reject) => {
+      pendingRequests.set(requestId, { resolve, reject })
+      let url: string
+      let requestInit: any = init ? { ...init } : {}
+
+      if (typeof input === "string" || input instanceof URL) {
+        url = input.toString()
+      } else {
+        url = input.url
+        requestInit = {
+          ...requestInit,
+          method: input.method,
+          headers: Object.fromEntries(input.headers.entries()),
+          body: input.bodyUsed ? undefined : (input as any).body,
+        }
+      }
+
+      if (requestInit.headers instanceof Headers) {
+        requestInit.headers = Object.fromEntries(requestInit.headers.entries())
+      }
+      ;(globalThis as any).postMessage({
+        type: "worker-fetch",
+        requestId,
+        input: url,
+        init: requestInit,
+      })
+    })
+  }
+
+  function handleMessage(event: MessageEvent) {
+    const data = event.data
+    if (!data) return
+
+    if (data.type === "override-global-fetch") {
+      ;(globalThis as any).fetch = fetchProxy
+      return
+    }
+
+    if (data.type === "worker-fetch-result") {
+      const handlers = pendingRequests.get(data.requestId)
+      if (!handlers) return
+      pendingRequests.delete(data.requestId)
+
+      if (data.success) {
+        const resp = new Response(data.response.body, {
+          status: data.response.status,
+          statusText: data.response.statusText,
+          headers: data.response.headers,
+        })
+        handlers.resolve(resp)
+      } else {
+        const err = new Error(data.error.message)
+        err.name = data.error.name
+        if (data.error.stack) err.stack = data.error.stack
+        handlers.reject(err)
+      }
+    }
+  }
+
+  globalThis.addEventListener("message", handleMessage)
+}

--- a/webworker/import-snippet.ts
+++ b/webworker/import-snippet.ts
@@ -12,7 +12,8 @@ export async function importSnippet(
   const { preSuppliedImports } = ctx
   const fullSnippetName = importName.replace("@tsci/", "").replace(".", "/")
 
-  const { cjs, error } = await fetch(`${ctx.cjsRegistryUrl}/${fullSnippetName}`)
+  const { cjs, error } = await globalThis
+    .fetch(`${ctx.cjsRegistryUrl}/${fullSnippetName}`)
     .then(async (res) => ({ cjs: await res.text(), error: null }))
     .catch((e) => ({ error: e, cjs: null }))
 


### PR DESCRIPTION
## Summary
- proxy worker fetch calls to the parent thread and reconstitute responses
- hook up fetch override when spawning worker
- add test demonstrating fetch override and error propagation

## Testing
- `bun run build:webworker`
- `bun test tests/fetch-override.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68a57ddc296083278698e66b1fa32f5a