### PR TITLE
Feat: Add support for importing local .obj files

### DIFF
--- a/lib/runner/resolveFilePath.ts
+++ b/lib/runner/resolveFilePath.ts
@@ -51,7 +51,7 @@ export const resolveFilePath = (
   }
 
   // Search for file with a set of different extensions
-  const extension = ["tsx", "ts", "json", "js", "jsx"]
+  const extension = ["tsx", "ts", "json", "js", "jsx", "obj"]
   for (const ext of extension) {
     const possibleFilePath = `${normalizedResolvedPath}.${ext}`
     if (normalizedFilePathMap.has(possibleFilePath)) {

--- a/tests/features/import-obj-file.test.tsx
+++ b/tests/features/import-obj-file.test.tsx
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test"
+import type {
+  AnyCircuitElement,
+  AnySourceComponent,
+  CadComponent,
+} from "circuit-json"
+import { CircuitRunner } from "lib/runner/CircuitRunner"
+
+test("should support importing .obj files", async () => {
+  const runner = new CircuitRunner()
+
+  const fsMap = {
+    "my-model.obj": `v 1.0 1.0 0.0`, // some dummy obj content
+    "user-code.tsx": `
+        import myObjUrl from "./my-model.obj"
+
+        export default () => (
+            <chip
+                name="C1"
+                cadModel={{
+                    objUrl: myObjUrl,
+                }}
+            />
+        )
+    `,
+  }
+
+  await runner.executeWithFsMap({
+    fsMap,
+    mainComponentPath: "user-code.tsx",
+  })
+
+  await runner.renderUntilSettled()
+  const circuitJson = await runner.getCircuitJson()
+
+  const chip =
+    (circuitJson.find(
+      (elm) => elm.type === "source_component" && elm.name === "C1",
+    ) as AnyCircuitElement) || undefined
+  const cadModel =
+    (circuitJson.find((elm) => elm.type === "cad_component") as CadComponent) ||
+    undefined
+
+  expect(chip).toBeDefined()
+  expect(cadModel?.model_obj_url).toBeString()
+  expect(cadModel?.model_obj_url).toStartWith("blob:")
+
+  await runner.kill()
+})

--- a/webworker/import-local-file.ts
+++ b/webworker/import-local-file.ts
@@ -34,6 +34,13 @@ export const importLocalFile = async (
       __esModule: true,
       default: jsonData,
     }
+  } else if (fsPath.endsWith(".obj")) {
+    const objBlob = new Blob([fileContent], { type: "model/obj" })
+    const objUrl = URL.createObjectURL(objBlob)
+    preSuppliedImports[fsPath] = {
+      __esModule: true,
+      default: objUrl,
+    }
   } else if (fsPath.endsWith(".tsx") || fsPath.endsWith(".ts")) {
     const importNames = getImportsFromCode(fileContent)
 


### PR DESCRIPTION
This PR introduces support for importing local `.obj` files, which are returned as blob URLs. This 
allows developers to use local 3D models for CAD components in their designs.                      
                                                                                                   
The implementation includes:                                                                       
- Updating the file resolution logic in `resolveFilePath.ts` to recognize the `.obj` extension.    
- Modifying `importLocalFile.ts` in the web worker to process `.obj` files, create a blob URL from 
their content, and provide it as the default export of the module.                                 
- Adding a new test case to verify that `.obj` files can be imported and their URLs are correctly  
applied to a component's `cadModel`. 