### PR TITLE
feat(webworker): Support NPM package imports

### DIFF
--- a/tests/features/npm-import.test.tsx
+++ b/tests/features/npm-import.test.tsx
@@ -1,0 +1,25 @@
+import { test, expect } from "bun:test"
+import { runTscircuitCode } from "lib/runner"
+
+test(
+  "should support importing from npm via unpkg",
+  async () => {
+    const circuitJson = await runTscircuitCode(
+      `
+    import isOdd from "is-odd"
+
+    export default () => {
+      if (!isOdd(3)) throw new Error("isOdd failed")
+      return <resistor name="R1" resistance="1k" />
+    }
+    `,
+    )
+
+    const resistor = circuitJson.find(
+      (element) => element.type === "source_component" && element.name === "R1",
+    )
+
+    expect(resistor).toBeDefined()
+  },
+  { timeout: 15000 },
+)

--- a/tests/features/npm-import.test.tsx
+++ b/tests/features/npm-import.test.tsx
@@ -2,14 +2,31 @@ import { test, expect } from "bun:test"
 import { runTscircuitCode } from "lib/runner"
 
 test(
-  "should support importing from npm via unpkg",
+  "should support importing various npm packages",
   async () => {
     const circuitJson = await runTscircuitCode(
       `
-    import isOdd from "is-odd"
+    import _ from "lodash"
+    import { v4 as uuidv4 } from "uuid"
+    import dayjs from "dayjs"
 
     export default () => {
-      if (!isOdd(3)) throw new Error("isOdd failed")
+      // Test lodash
+      if (!_.isEqual({ a: 1 }, { a: 1 })) {
+        throw new Error("_.isEqual failed")
+      }
+
+      // Test uuid
+      const uuid = uuidv4()
+      if (typeof uuid !== "string" || uuid.length < 36) {
+        throw new Error("uuid.v4 failed to generate a valid uuid")
+      }
+
+      // Test dayjs
+      if (!dayjs().isValid()) {
+        throw new Error("dayjs().isValid() failed")
+      }
+      
       return <resistor name="R1" resistance="1k" />
     }
     `,

--- a/webworker/import-eval-path.ts
+++ b/webworker/import-eval-path.ts
@@ -6,6 +6,7 @@ import { importSnippet } from "./import-snippet"
 import { resolveFilePath } from "lib/runner/resolveFilePath"
 import { resolveNodeModule } from "lib/utils/resolve-node-module"
 import { importNodeModule } from "./import-node-module"
+import { importNpmPackage } from "./import-npm-package"
 import Debug from "debug"
 
 const debug = Debug("tsci:eval:import-eval-path")
@@ -57,6 +58,10 @@ export async function importEvalPath(
 
   if (importName.startsWith("@tsci/")) {
     return importSnippet(importName, ctx, depth)
+  }
+
+  if (!importName.startsWith(".") && !importName.startsWith("/")) {
+    return importNpmPackage(importName, ctx, depth)
   }
 
   throw new Error(

--- a/webworker/import-eval-path.ts
+++ b/webworker/import-eval-path.ts
@@ -61,7 +61,7 @@ export async function importEvalPath(
   }
 
   if (!importName.startsWith(".") && !importName.startsWith("/")) {
-    return importNpmPackage(importName, ctx, depth)
+    return importNpmPackage(importName, ctx)
   }
 
   throw new Error(

--- a/webworker/import-npm-package.ts
+++ b/webworker/import-npm-package.ts
@@ -1,0 +1,56 @@
+import { evalCompiledJs } from "./eval-compiled-js"
+import type { ExecutionContext } from "./execution-context"
+import { importEvalPath } from "./import-eval-path"
+import Debug from "debug"
+
+const debug = Debug("tsci:eval:import-npm-package")
+
+export async function importNpmPackage(
+  importName: string,
+  ctx: ExecutionContext,
+  depth = 0,
+) {
+  debug(`importing npm package: ${importName}`)
+  const { preSuppliedImports } = ctx
+
+  if (preSuppliedImports[importName]) return
+
+  const npmCdnUrl = `https://unpkg.com/${importName}`
+
+  const { content, error } = await globalThis
+    .fetch(npmCdnUrl)
+    .then(async (res) => {
+      if (!res.ok)
+        throw new Error(
+          `Could not fetch "${importName}" from unpkg: ${res.statusText}`,
+        )
+      return { content: await res.text(), error: null }
+    })
+    .catch((e) => ({ error: e, content: null }))
+
+  if (error) {
+    console.error("Error fetching npm import", importName, error)
+    throw error
+  }
+
+  const requireRegex = /\brequire\s*\(\s*["']([^"']+)["']\s*\)/g
+  const dependencies = new Set<string>()
+  let match
+  // biome-ignore lint/suspicious/noAssignInExpressions: <explanation>
+  while ((match = requireRegex.exec(content!))) {
+    dependencies.add(match[1])
+  }
+
+  for (const dep of dependencies) {
+    await importEvalPath(dep, ctx, depth + 1)
+  }
+
+  try {
+    preSuppliedImports[importName] = evalCompiledJs(
+      content!,
+      preSuppliedImports,
+    ).exports
+  } catch (e: any) {
+    throw new Error(`Eval npm package error for "${importName}": ${e.message}`)
+  }
+}

--- a/webworker/import-npm-package.ts
+++ b/webworker/import-npm-package.ts
@@ -1,28 +1,38 @@
 import { evalCompiledJs } from "./eval-compiled-js"
 import type { ExecutionContext } from "./execution-context"
-import { importEvalPath } from "./import-eval-path"
+import * as Babel from "@babel/standalone"
+import { dirname } from "lib/utils/dirname"
 import Debug from "debug"
 
 const debug = Debug("tsci:eval:import-npm-package")
 
+function extractPackagePathFromJSDelivr(url: string) {
+  const prefix = "https://cdn.jsdelivr.net/npm/"
+  if (url.startsWith(prefix)) {
+    return url.substring(prefix.length).replace(/\/\+esm$/, "")
+  }
+  return url
+}
+
 export async function importNpmPackage(
   importName: string,
   ctx: ExecutionContext,
-  depth = 0,
 ) {
   debug(`importing npm package: ${importName}`)
   const { preSuppliedImports } = ctx
 
   if (preSuppliedImports[importName]) return
 
-  const npmCdnUrl = `https://unpkg.com/${importName}`
+  const npmCdnUrl = `https://cdn.jsdelivr.net/npm/${importName}/+esm`
 
+  let finalUrl: string | undefined
   const { content, error } = await globalThis
     .fetch(npmCdnUrl)
     .then(async (res) => {
+      finalUrl = res.url
       if (!res.ok)
         throw new Error(
-          `Could not fetch "${importName}" from unpkg: ${res.statusText}`,
+          `Could not fetch "${importName}" from jsdelivr: ${res.statusText}`,
         )
       return { content: await res.text(), error: null }
     })
@@ -33,21 +43,26 @@ export async function importNpmPackage(
     throw error
   }
 
-  const requireRegex = /\brequire\s*\(\s*["']([^"']+)["']\s*\)/g
-  const dependencies = new Set<string>()
-  for (const match of content!.matchAll(requireRegex)) {
-    dependencies.add(match[1])
-  }
+  const transpiled = Babel.transform(content!, {
+    presets: ["react", "env"],
+    plugins: ["transform-modules-commonjs"],
+    filename: importName,
+  })
 
-  for (const dep of dependencies) {
-    await importEvalPath(dep, ctx, depth + 1)
+  if (!transpiled.code) {
+    throw new Error(`Babel transpilation failed for ${importName}`)
   }
-
   try {
-    preSuppliedImports[importName] = evalCompiledJs(
-      content!,
+    const finalImportName = extractPackagePathFromJSDelivr(finalUrl!)
+    const cwd = dirname(finalImportName)
+    const exports = evalCompiledJs(
+      transpiled.code!,
       preSuppliedImports,
+      cwd,
     ).exports
+    preSuppliedImports[importName] = exports
+    preSuppliedImports[finalImportName] = exports
+    preSuppliedImports[finalUrl!] = exports
   } catch (e: any) {
     throw new Error(`Eval npm package error for "${importName}": ${e.message}`)
   }

--- a/webworker/import-npm-package.ts
+++ b/webworker/import-npm-package.ts
@@ -35,9 +35,7 @@ export async function importNpmPackage(
 
   const requireRegex = /\brequire\s*\(\s*["']([^"']+)["']\s*\)/g
   const dependencies = new Set<string>()
-  let match
-  // biome-ignore lint/suspicious/noAssignInExpressions: <explanation>
-  while ((match = requireRegex.exec(content!))) {
+  for (const match of content!.matchAll(requireRegex)) {
     dependencies.add(match[1])
   }
 


### PR DESCRIPTION
RE tscircuit/tscircuit#760

This PR introduces the capability to import npm packages directly from code evaluated in the web worker. Users can now  
add imports for packages like lodash or uuid, and they will be dynamically fetched, bundled, and made available in the execution environment.                                                                                                                     

 • Non-relative imports are treated as requests for npm packages.                                                                
 • Packages are fetched from the jsdelivr CDN using the +esm endpoint, which provides a single, pre-bundled file with all        
   dependencies included.                                                                                                        
 • The fetched code is transpiled via Babel to ensure compatibility.                                                             
 • The module is then executed and its exports are cached, making them available to the user's code.