### PR TITLE
feat: Support importing GLTF files with binary assets

### DIFF
--- a/lib/runner/resolveFilePath.ts
+++ b/lib/runner/resolveFilePath.ts
@@ -51,7 +51,7 @@ export const resolveFilePath = (
   }
 
   // Search for file with a set of different extensions
-  const extension = ["tsx", "ts", "json", "js", "jsx", "obj"]
+  const extension = ["tsx", "ts", "json", "js", "jsx", "obj", "gltf", "glb"]
   for (const ext of extension) {
     const possibleFilePath = `${normalizedResolvedPath}.${ext}`
     if (normalizedFilePathMap.has(possibleFilePath)) {

--- a/tests/features/import-gltf-file.test.tsx
+++ b/tests/features/import-gltf-file.test.tsx
@@ -1,0 +1,78 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement, CadComponent } from "circuit-json"
+import { CircuitRunner } from "lib/runner/CircuitRunner"
+
+test("should support importing .gltf files with binary", async () => {
+  const runner = new CircuitRunner()
+
+  const gltfContent = {
+    asset: { version: "2.0" },
+    scenes: [{ nodes: [0] }],
+    nodes: [{ mesh: 0 }],
+    meshes: [
+      {
+        primitives: [{ attributes: { POSITION: 0 } }],
+      },
+    ],
+    buffers: [{ uri: "model.bin", byteLength: 36 }],
+    bufferViews: [{ buffer: 0, byteOffset: 0, byteLength: 36 }],
+    accessors: [
+      {
+        bufferView: 0,
+        componentType: 5126, // FLOAT
+        count: 3,
+        type: "VEC3",
+      },
+    ],
+  }
+
+  const binContent = "This is a dummy binary file content.".padEnd(36, "\0")
+
+  const fsMap = {
+    "my-model.gltf": JSON.stringify(gltfContent),
+    "model.bin": binContent,
+    "user-code.tsx": `
+        import myGltfUrl from "./my-model.gltf"
+
+        export default () => (
+            <chip
+                name="C1"
+                cadModel={{
+                    gltfUrl: myGltfUrl,
+                }}
+            />
+        )
+    `,
+  }
+
+  await runner.executeWithFsMap({
+    fsMap,
+    mainComponentPath: "user-code.tsx",
+  })
+
+  await runner.renderUntilSettled()
+  const circuitJson = await runner.getCircuitJson()
+
+  const chip =
+    (circuitJson.find(
+      (elm) => elm.type === "source_component" && elm.name === "C1",
+    ) as AnyCircuitElement) || undefined
+  const cadModel =
+    (circuitJson.find((elm) => elm.type === "cad_component") as CadComponent) ||
+    undefined
+
+  expect(chip).toBeDefined()
+  expect(cadModel?.model_gltf_url).toBeString()
+  expect(cadModel?.model_gltf_url).toStartWith("blob:")
+
+  if (cadModel?.model_gltf_url) {
+    const response = await fetch(cadModel.model_gltf_url)
+    const text = await response.text()
+    const json = JSON.parse(text)
+    expect(json.buffers[0].uri).toStartWith(
+      "data:application/octet-stream;base64,",
+    )
+  }
+
+  await runner.kill()
+})


### PR DESCRIPTION
This PR introduces support for importing `.gltf` files that have dependencies on external binary (`.bin`) or image assets.                                                                                            
                                                                                                 
1.  **File Resolution**: The `resolveFilePath` utility now recognizes the `.gltf` file extension.                 
2.  **Asset Inlining**: When a `.gltf` file is imported within the web worker:                                                       
    - The JSON file is parsed.                                                                                                       
    - It iterates through `buffers` and `images` to find any relative URIs.                                                          
    - For each relative URI, it resolves the path, reads the corresponding file from the `fsMap`, and converts its content into a    
`data:` URI (base64).                                                                                                                
    - This `data:` URI replaces the original relative URI in the GLTF JSON structure.                                                
3.  **Blob URL Creation**: A new `Blob` is created from the modified GLTF JSON, and a `blob:` URL is generated to represent the      
final, self-contained asset. This URL is returned as the default export of the imported module.                                      
                                                                                                               
A new integration test (`tests/features/import-gltf-file.test.tsx`) has been added to validate this feature. The test ensures that a `.gltf` file referencing an external `.bin` file is correctly processed and that the final `blob:` URL contains the inlined binary   
data as a `data:` URI.     