### PR TITLE
feat: support glb imports

### DIFF
--- a/tests/features/import-glb-file.test.tsx
+++ b/tests/features/import-glb-file.test.tsx
@@ -1,0 +1,54 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement, CadComponent } from "circuit-json"
+import { CircuitRunner } from "lib/runner/CircuitRunner"
+
+test("should support importing .glb files", async () => {
+  const runner = new CircuitRunner()
+
+  const glbContent = "This is a dummy glb file"
+
+  const fsMap = {
+    "my-model.glb": glbContent,
+    "user-code.tsx": `
+        import myGlbUrl from "./my-model.glb"
+
+        export default () => (
+            <chip
+                name="C1"
+                cadModel={{
+                    gltfUrl: myGlbUrl,
+                }}
+            />
+        )
+    `,
+  }
+
+  await runner.executeWithFsMap({
+    fsMap,
+    mainComponentPath: "user-code.tsx",
+  })
+
+  await runner.renderUntilSettled()
+  const circuitJson = await runner.getCircuitJson()
+
+  const chip =
+    (circuitJson.find(
+      (elm) => elm.type === "source_component" && elm.name === "C1",
+    ) as AnyCircuitElement) || undefined
+  const cadModel =
+    (circuitJson.find((elm) => elm.type === "cad_component") as CadComponent) ||
+    undefined
+
+  expect(chip).toBeDefined()
+  expect(cadModel?.model_gltf_url).toBeString()
+  expect(cadModel?.model_gltf_url).toStartWith("blob:")
+
+  if (cadModel?.model_gltf_url) {
+    const response = await fetch(cadModel.model_gltf_url)
+    const arrayBuffer = await response.arrayBuffer()
+    const text = new TextDecoder().decode(arrayBuffer)
+    expect(text).toBe(glbContent)
+  }
+
+  await runner.kill()
+})

--- a/webworker/import-local-file.ts
+++ b/webworker/import-local-file.ts
@@ -44,6 +44,14 @@ export const importLocalFile = async (
       __esModule: true,
       default: objUrl,
     }
+  } else if (fsPath.endsWith(".glb")) {
+    const glbArray = Uint8Array.from(fileContent, (c) => c.charCodeAt(0))
+    const glbBlob = new Blob([glbArray], { type: "model/gltf-binary" })
+    const glbUrl = URL.createObjectURL(glbBlob)
+    preSuppliedImports[fsPath] = {
+      __esModule: true,
+      default: glbUrl,
+    }
   } else if (fsPath.endsWith(".gltf")) {
     const gltfJson = JSON.parse(fileContent)
     const fileDir = dirname(fsPath)


### PR DESCRIPTION
## Summary
- handle `.glb` files when importing local assets by converting them to object URLs
- add regression test ensuring local `.glb` files can be imported

## Testing
- `bunx tsc --noEmit`
- `bun test tests/features/import-glb-file.test.tsx tests/features/import-gltf-file.test.tsx tests/features/import-obj-file.test.tsx`


------
https://chatgpt.com/codex/tasks/task_b_68c3a6a364a8832eb1c2478581abc544