### PR TITLE
feat: allow project config to override platform

### DIFF
--- a/lib/runner/CircuitRunner.ts
+++ b/lib/runner/CircuitRunner.ts
@@ -11,6 +11,7 @@ import * as React from "react"
 import { importEvalPath } from "webworker/import-eval-path"
 import { setupDefaultEntrypointIfNeeded } from "./setupDefaultEntrypointIfNeeded"
 import Debug from "debug"
+import { getPlatformConfig } from "../getPlatformConfig"
 
 const debug = Debug("tsci:eval:CircuitRunner")
 
@@ -26,6 +27,14 @@ export class CircuitRunner implements CircuitRunnerApi {
 
   constructor(configuration: Partial<CircuitRunnerConfiguration> = {}) {
     Object.assign(this._circuitRunnerConfiguration, configuration)
+  }
+
+  private _getPlatformConfig(): PlatformConfig {
+    return {
+      ...getPlatformConfig(),
+      ...this._circuitRunnerConfiguration.platform,
+      ...this._circuitRunnerConfiguration.projectConfig,
+    }
   }
 
   async version(): Promise<string> {
@@ -62,7 +71,7 @@ export class CircuitRunner implements CircuitRunnerApi {
       this._circuitRunnerConfiguration,
       {
         name: opts.name,
-        platform: this._circuitRunnerConfiguration.platform,
+        platform: this._getPlatformConfig(),
         debugNamespace: this._debugNamespace,
       },
     )
@@ -94,7 +103,7 @@ export class CircuitRunner implements CircuitRunnerApi {
       this._circuitRunnerConfiguration,
       {
         ...opts,
-        platform: this._circuitRunnerConfiguration.platform,
+        platform: this._getPlatformConfig(),
         debugNamespace: this._debugNamespace,
       },
     )
@@ -114,7 +123,7 @@ export class CircuitRunner implements CircuitRunnerApi {
       this._circuitRunnerConfiguration,
       {
         ...opts,
-        platform: this._circuitRunnerConfiguration.platform,
+        platform: this._getPlatformConfig(),
         debugNamespace: this._debugNamespace,
       },
     )

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -4,11 +4,16 @@ import type { PlatformConfig } from "@tscircuit/props"
 
 export type RootCircuitEventName = CoreRootCircuitEventName | "debug:logOutput"
 
+export interface ProjectConfig {
+  projectBaseUrl?: string
+}
+
 export interface CircuitRunnerConfiguration {
   snippetsApiBaseUrl: string
   cjsRegistryUrl: string
   verbose?: boolean
   platform?: PlatformConfig
+  projectConfig?: ProjectConfig
 }
 
 export interface WebWorkerConfiguration extends CircuitRunnerConfiguration {

--- a/lib/worker.ts
+++ b/lib/worker.ts
@@ -6,6 +6,7 @@ import type {
   CircuitWebWorker,
 } from "./shared/types"
 import type { RootCircuitEventName } from "./shared/types"
+import { getPlatformConfig } from "./getPlatformConfig"
 
 export type { CircuitWebWorker, WebWorkerConfiguration }
 
@@ -170,8 +171,17 @@ export const createCircuitWebWorker = async (
   if (configuration.snippetsApiBaseUrl) {
     await comlinkWorker.setSnippetsApiBaseUrl(configuration.snippetsApiBaseUrl)
   }
-  if (configuration.platform) {
-    await comlinkWorker.setPlatformConfig(configuration.platform)
+  const finalPlatformConfig =
+    configuration.platform || configuration.projectConfig
+      ? {
+          ...getPlatformConfig(),
+          ...configuration.platform,
+          ...configuration.projectConfig,
+        }
+      : undefined
+
+  if (finalPlatformConfig) {
+    await comlinkWorker.setPlatformConfig(finalPlatformConfig)
   }
 
   let isTerminated = false

--- a/tests/features/project-config.test.tsx
+++ b/tests/features/project-config.test.tsx
@@ -1,0 +1,23 @@
+import { CircuitRunner } from "lib/runner/CircuitRunner"
+import { expect, test } from "bun:test"
+
+test("project configuration overrides platform defaults", async () => {
+  const runner = new CircuitRunner({
+    projectConfig: { projectBaseUrl: "https://example.com/assets" },
+  })
+
+  await runner.execute(`
+    circuit.add(
+      <board width="10mm" height="10mm">
+        <resistor name="R1" resistance="1k" footprint="0402" />
+      </board>
+    )
+  `)
+
+  await runner.renderUntilSettled()
+  const circuit = (globalThis as any).__tscircuit_circuit
+  expect(circuit.platform?.projectBaseUrl).toBe("https://example.com/assets")
+  expect(circuit.platform?.partsEngine).toBeDefined()
+
+  await runner.kill()
+})


### PR DESCRIPTION
## Summary
- allow providing `projectConfig` to CircuitRunner to override default platform settings
- compute merged platform config in runner and worker utilities
- test projectConfig overrides while keeping defaults

## Testing
- `bunx tsc --noEmit && echo tsc_ok`
- `bun test tests/features/project-config.test.tsx`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_68c4f0780938832e82c4712c3a283990