### PR TITLE
feat: allow overriding some platform config values with `projectConfig`

### DIFF
--- a/lib/runner/CircuitRunner.ts
+++ b/lib/runner/CircuitRunner.ts
@@ -63,6 +63,7 @@ export class CircuitRunner implements CircuitRunnerApi {
       {
         name: opts.name,
         platform: this._circuitRunnerConfiguration.platform,
+        projectSettings: this._circuitRunnerConfiguration.projectSettings,
         debugNamespace: this._debugNamespace,
       },
     )
@@ -95,6 +96,7 @@ export class CircuitRunner implements CircuitRunnerApi {
       {
         ...opts,
         platform: this._circuitRunnerConfiguration.platform,
+        projectSettings: this._circuitRunnerConfiguration.projectSettings,
         debugNamespace: this._debugNamespace,
       },
     )
@@ -115,6 +117,7 @@ export class CircuitRunner implements CircuitRunnerApi {
       {
         ...opts,
         platform: this._circuitRunnerConfiguration.platform,
+        projectSettings: this._circuitRunnerConfiguration.projectSettings,
         debugNamespace: this._debugNamespace,
       },
     )
@@ -174,6 +177,10 @@ export class CircuitRunner implements CircuitRunnerApi {
 
   async setPlatformConfig(platform: PlatformConfig) {
     this._circuitRunnerConfiguration.platform = platform
+  }
+
+  async setProjectSettings(project: Partial<PlatformConfig>) {
+    this._circuitRunnerConfiguration.projectSettings = project
   }
 
   async enableDebug(namespace: string) {

--- a/lib/runner/CircuitRunner.ts
+++ b/lib/runner/CircuitRunner.ts
@@ -63,7 +63,7 @@ export class CircuitRunner implements CircuitRunnerApi {
       {
         name: opts.name,
         platform: this._circuitRunnerConfiguration.platform,
-        projectSettings: this._circuitRunnerConfiguration.projectSettings,
+        projectConfig: this._circuitRunnerConfiguration.projectConfig,
         debugNamespace: this._debugNamespace,
       },
     )
@@ -96,7 +96,7 @@ export class CircuitRunner implements CircuitRunnerApi {
       {
         ...opts,
         platform: this._circuitRunnerConfiguration.platform,
-        projectSettings: this._circuitRunnerConfiguration.projectSettings,
+        projectConfig: this._circuitRunnerConfiguration.projectConfig,
         debugNamespace: this._debugNamespace,
       },
     )
@@ -117,7 +117,7 @@ export class CircuitRunner implements CircuitRunnerApi {
       {
         ...opts,
         platform: this._circuitRunnerConfiguration.platform,
-        projectSettings: this._circuitRunnerConfiguration.projectSettings,
+        projectConfig: this._circuitRunnerConfiguration.projectConfig,
         debugNamespace: this._debugNamespace,
       },
     )
@@ -179,8 +179,8 @@ export class CircuitRunner implements CircuitRunnerApi {
     this._circuitRunnerConfiguration.platform = platform
   }
 
-  async setProjectSettings(project: Partial<PlatformConfig>) {
-    this._circuitRunnerConfiguration.projectSettings = project
+  async setProjectConfig(project: Partial<PlatformConfig>) {
+    this._circuitRunnerConfiguration.projectConfig = project
   }
 
   async enableDebug(namespace: string) {

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -9,7 +9,7 @@ export interface CircuitRunnerConfiguration {
   cjsRegistryUrl: string
   verbose?: boolean
   platform?: PlatformConfig
-  projectSettings?: Partial<PlatformConfig>
+  projectConfig?: Partial<PlatformConfig>
 }
 
 export interface WebWorkerConfiguration extends CircuitRunnerConfiguration {
@@ -49,7 +49,7 @@ export interface CircuitRunnerApi {
   getCircuitJson: () => Promise<AnyCircuitElement[]>
   setSnippetsApiBaseUrl: (baseUrl: string) => Promise<void>
   setPlatformConfig: (platform: PlatformConfig) => Promise<void>
-  setProjectSettings: (project: Partial<PlatformConfig>) => Promise<void>
+  setProjectConfig: (project: Partial<PlatformConfig>) => Promise<void>
   enableDebug: (namespace: string) => Promise<void>
   on: (event: RootCircuitEventName, callback: (...args: any[]) => void) => void
   clearEventListeners: () => void

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -9,6 +9,7 @@ export interface CircuitRunnerConfiguration {
   cjsRegistryUrl: string
   verbose?: boolean
   platform?: PlatformConfig
+  projectSettings?: Partial<PlatformConfig>
 }
 
 export interface WebWorkerConfiguration extends CircuitRunnerConfiguration {
@@ -48,6 +49,7 @@ export interface CircuitRunnerApi {
   getCircuitJson: () => Promise<AnyCircuitElement[]>
   setSnippetsApiBaseUrl: (baseUrl: string) => Promise<void>
   setPlatformConfig: (platform: PlatformConfig) => Promise<void>
+  setProjectSettings: (project: Partial<PlatformConfig>) => Promise<void>
   enableDebug: (namespace: string) => Promise<void>
   on: (event: RootCircuitEventName, callback: (...args: any[]) => void) => void
   clearEventListeners: () => void

--- a/lib/worker.ts
+++ b/lib/worker.ts
@@ -173,6 +173,9 @@ export const createCircuitWebWorker = async (
   if (configuration.platform) {
     await comlinkWorker.setPlatformConfig(configuration.platform)
   }
+  if (configuration.projectSettings) {
+    await comlinkWorker.setProjectSettings(configuration.projectSettings)
+  }
 
   let isTerminated = false
 

--- a/lib/worker.ts
+++ b/lib/worker.ts
@@ -173,8 +173,8 @@ export const createCircuitWebWorker = async (
   if (configuration.platform) {
     await comlinkWorker.setPlatformConfig(configuration.platform)
   }
-  if (configuration.projectSettings) {
-    await comlinkWorker.setProjectSettings(configuration.projectSettings)
+  if (configuration.projectConfig) {
+    await comlinkWorker.setProjectConfig(configuration.projectConfig)
   }
 
   let isTerminated = false

--- a/tests/features/project-config.test.tsx
+++ b/tests/features/project-config.test.tsx
@@ -1,9 +1,9 @@
 import { CircuitRunner } from "lib/runner/CircuitRunner"
 import { expect, test } from "bun:test"
 
-test("projectSettings overrides default platform config", async () => {
+test("projectConfig overrides default platform config", async () => {
   const runner = new CircuitRunner({
-    projectSettings: {
+    projectConfig: {
       projectBaseUrl: "https://example.com/assets",
     },
   })

--- a/tests/features/project-settings.test.tsx
+++ b/tests/features/project-settings.test.tsx
@@ -1,0 +1,25 @@
+import { CircuitRunner } from "lib/runner/CircuitRunner"
+import { expect, test } from "bun:test"
+
+test("projectSettings overrides default platform config", async () => {
+  const runner = new CircuitRunner({
+    projectSettings: {
+      projectBaseUrl: "https://example.com/assets",
+    },
+  })
+
+  await runner.execute(`
+    circuit.add(
+      <board width="10mm" height="10mm">
+        <resistor name="R1" resistance="1k" footprint="0402" />
+      </board>
+    )
+  `)
+
+  await runner.renderUntilSettled()
+  const circuit = (globalThis as any).__tscircuit_circuit
+  expect(circuit.platform?.projectBaseUrl).toBe("https://example.com/assets")
+  expect(typeof circuit.platform?.footprintLibraryMap?.kicad).toBe("function")
+
+  await runner.kill()
+})

--- a/webworker/entrypoint.ts
+++ b/webworker/entrypoint.ts
@@ -27,7 +27,7 @@ const circuitRunnerConfiguration: WebWorkerConfiguration = {
   cjsRegistryUrl: "https://cjs.tscircuit.com",
   verbose: false,
   platform: undefined,
-  projectSettings: undefined,
+  projectConfig: undefined,
 }
 
 const eventListeners: Record<string, ((...args: any[]) => void)[]> = {}
@@ -81,8 +81,8 @@ const webWorkerApi = {
   setPlatformConfig: async (platform: PlatformConfig) => {
     circuitRunnerConfiguration.platform = platform
   },
-  setProjectSettings: async (project: Partial<PlatformConfig>) => {
-    circuitRunnerConfiguration.projectSettings = project
+  setProjectConfig: async (project: Partial<PlatformConfig>) => {
+    circuitRunnerConfiguration.projectConfig = project
   },
 
   enableDebug: async (namespace: string) => {
@@ -117,7 +117,7 @@ const webWorkerApi = {
     executionContext = createExecutionContext(circuitRunnerConfiguration, {
       name: opts.name,
       platform: circuitRunnerConfiguration.platform,
-      projectSettings: circuitRunnerConfiguration.projectSettings,
+      projectConfig: circuitRunnerConfiguration.projectConfig,
       debugNamespace,
     })
     bindEventListeners(executionContext.circuit)
@@ -141,7 +141,7 @@ const webWorkerApi = {
     executionContext = createExecutionContext(circuitRunnerConfiguration, {
       ...opts,
       platform: circuitRunnerConfiguration.platform,
-      projectSettings: circuitRunnerConfiguration.projectSettings,
+      projectConfig: circuitRunnerConfiguration.projectConfig,
       debugNamespace,
     })
     bindEventListeners(executionContext.circuit)
@@ -158,7 +158,7 @@ const webWorkerApi = {
     executionContext = createExecutionContext(circuitRunnerConfiguration, {
       ...opts,
       platform: circuitRunnerConfiguration.platform,
-      projectSettings: circuitRunnerConfiguration.projectSettings,
+      projectConfig: circuitRunnerConfiguration.projectConfig,
       debugNamespace,
     })
     bindEventListeners(executionContext.circuit)

--- a/webworker/entrypoint.ts
+++ b/webworker/entrypoint.ts
@@ -27,6 +27,7 @@ const circuitRunnerConfiguration: WebWorkerConfiguration = {
   cjsRegistryUrl: "https://cjs.tscircuit.com",
   verbose: false,
   platform: undefined,
+  projectSettings: undefined,
 }
 
 const eventListeners: Record<string, ((...args: any[]) => void)[]> = {}
@@ -80,6 +81,9 @@ const webWorkerApi = {
   setPlatformConfig: async (platform: PlatformConfig) => {
     circuitRunnerConfiguration.platform = platform
   },
+  setProjectSettings: async (project: Partial<PlatformConfig>) => {
+    circuitRunnerConfiguration.projectSettings = project
+  },
 
   enableDebug: async (namespace: string) => {
     debugNamespace = namespace
@@ -113,6 +117,7 @@ const webWorkerApi = {
     executionContext = createExecutionContext(circuitRunnerConfiguration, {
       name: opts.name,
       platform: circuitRunnerConfiguration.platform,
+      projectSettings: circuitRunnerConfiguration.projectSettings,
       debugNamespace,
     })
     bindEventListeners(executionContext.circuit)
@@ -136,6 +141,7 @@ const webWorkerApi = {
     executionContext = createExecutionContext(circuitRunnerConfiguration, {
       ...opts,
       platform: circuitRunnerConfiguration.platform,
+      projectSettings: circuitRunnerConfiguration.projectSettings,
       debugNamespace,
     })
     bindEventListeners(executionContext.circuit)
@@ -152,6 +158,7 @@ const webWorkerApi = {
     executionContext = createExecutionContext(circuitRunnerConfiguration, {
       ...opts,
       platform: circuitRunnerConfiguration.platform,
+      projectSettings: circuitRunnerConfiguration.projectSettings,
       debugNamespace,
     })
     bindEventListeners(executionContext.circuit)

--- a/webworker/execution-context.ts
+++ b/webworker/execution-context.ts
@@ -21,15 +21,15 @@ export function createExecutionContext(
   opts: {
     name?: string
     platform?: PlatformConfig
-    projectSettings?: Partial<PlatformConfig>
+    projectConfig?: Partial<PlatformConfig>
     debugNamespace?: string
   } = {},
 ): ExecutionContext {
   globalThis.React = React
 
   const basePlatform = opts.platform || getPlatformConfig()
-  const platform = opts.projectSettings
-    ? { ...basePlatform, ...opts.projectSettings }
+  const platform = opts.projectConfig
+    ? { ...basePlatform, ...opts.projectConfig }
     : basePlatform
 
   const circuit = new RootCircuit({

--- a/webworker/execution-context.ts
+++ b/webworker/execution-context.ts
@@ -21,13 +21,19 @@ export function createExecutionContext(
   opts: {
     name?: string
     platform?: PlatformConfig
+    projectSettings?: Partial<PlatformConfig>
     debugNamespace?: string
   } = {},
 ): ExecutionContext {
   globalThis.React = React
 
+  const basePlatform = opts.platform || getPlatformConfig()
+  const platform = opts.projectSettings
+    ? { ...basePlatform, ...opts.projectSettings }
+    : basePlatform
+
   const circuit = new RootCircuit({
-    platform: opts.platform || getPlatformConfig(),
+    platform,
   })
 
   if (opts.name) {


### PR DESCRIPTION
## Summary
- allow passing project-specific settings to CircuitRunner configuration
- forward project settings through worker and merge with base platform config
- add tests for project settings override behavior

## Testing
- `bunx tsc --noEmit`
- `bun test tests/features/project-settings.test.tsx`
- `bun test tests/features/platform-config.test.tsx`
- `bun test tests/node-resolution`
- `bun test tests/circuit-runner` *(fails: Eval compiled js error for "entrypoint.tsx": Import "@tsci/seveibar.red-led" not found in ".")*

------
https://chatgpt.com/codex/tasks/task_b_68c4f02b6c80832ebef207cf0b16398e