### PR TITLE
Retry tests on segfault

### DIFF
--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -41,4 +41,18 @@ jobs:
 
       - run: bun run build
       - name: Run tests for ${{ matrix.test-dir }}
-        run: bun test tests/${{ matrix.test-dir }} --timeout 30000
+        run: |
+          set +e
+          for i in 1 2 3; do
+            bun test tests/${{ matrix.test-dir }} --timeout 30000
+            code=$?
+            if [ $code -eq 0 ]; then
+              exit 0
+            fi
+            if [ $code -ne 139 ]; then
+              exit $code
+            fi
+            echo "Segmentation fault detected, retrying ($i/3)..."
+          done
+          echo "Tests failed due to segmentation fault after 3 attempts."
+          exit 139


### PR DESCRIPTION
## Summary
- retry bun tests on segmentation faults for up to three attempts

## Testing
- `bunx tsc --noEmit`
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/util-fns --timeout 30000`


------
https://chatgpt.com/codex/tasks/task_b_68c4e00d4e98832eb31155ab74e01f89