### PR TITLE
refactor: replace babel standalone with sucrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @tscircuit/eval
 
-Evaluate code in a full tscircuit runtime environment, including babel
+Evaluate code in a full tscircuit runtime environment, including Sucrase
 transpilation and execution, so you just need to send the code to be executed
 with automatic handling of imports from `@tsci/*`
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     }
   },
   "devDependencies": {
-    "@babel/standalone": "^7.28.0",
     "@biomejs/biome": "^1.8.3",
     "@playwright/test": "^1.50.1",
     "@tscircuit/capacity-autorouter": "^0.0.107",
@@ -72,7 +71,7 @@
     "@tscircuit/schematic-match-adapt": "^0.0.16",
     "@tscircuit/schematic-trace-solver": "^0.0.37",
     "@tscircuit/simple-3d-svg": "^0.0.41",
-    "@types/babel__standalone": "^7.1.9",
+    "sucrase": "^3.35.0",
     "@types/bun": "^1.2.16",
     "@types/debug": "^4.1.12",
     "@types/react": "^19.1.8",

--- a/tsup-webworker.config.ts
+++ b/tsup-webworker.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     "@tscircuit/core",
     "circuit-json",
     "@tscircuit/parts-engine",
-    "@babel/standalone",
+    "sucrase",
     "@tscircuit/math-utils",
     "zod",
   ],

--- a/webworker/import-eval-path.ts
+++ b/webworker/import-eval-path.ts
@@ -1,6 +1,4 @@
-import { evalCompiledJs } from "./eval-compiled-js"
 import type { ExecutionContext } from "./execution-context"
-import * as Babel from "@babel/standalone"
 import { importLocalFile } from "./import-local-file"
 import { importSnippet } from "./import-snippet"
 import { resolveFilePath } from "lib/runner/resolveFilePath"

--- a/webworker/import-npm-package.ts
+++ b/webworker/import-npm-package.ts
@@ -1,10 +1,10 @@
 import { evalCompiledJs } from "./eval-compiled-js"
 import type { ExecutionContext } from "./execution-context"
-import * as Babel from "@babel/standalone"
 import { dirname } from "lib/utils/dirname"
 import Debug from "debug"
 import { getImportsFromCode } from "lib/utils/get-imports-from-code"
 import { importEvalPath } from "./import-eval-path"
+import { transformWithSucrase } from "./transform-with-sucrase"
 
 const debug = Debug("tsci:eval:import-npm-package")
 
@@ -58,18 +58,13 @@ export async function importNpmPackage(
     }
   }
 
-  const transpiled = Babel.transform(content!, {
-    presets: ["react", "env"],
-    plugins: ["transform-modules-commonjs"],
-    filename: importName,
-  })
-
-  if (!transpiled.code) {
-    throw new Error(`Babel transpilation failed for ${importName}`)
-  }
+  const transformedCode = transformWithSucrase(
+    content!,
+    finalImportName || importName,
+  )
   try {
     const exports = evalCompiledJs(
-      transpiled.code!,
+      transformedCode,
       preSuppliedImports,
       cwd,
     ).exports

--- a/webworker/transform-with-sucrase.ts
+++ b/webworker/transform-with-sucrase.ts
@@ -1,0 +1,68 @@
+import { transform, type Transform as SucraseTransform } from "sucrase"
+
+const TS_EXTENSIONS = new Set([".ts", ".tsx", ".mts", ".cts"])
+const JSX_EXTENSIONS = new Set([".tsx", ".jsx"])
+
+const stripQueryAndHash = (filePath: string) => {
+  const queryIndex = filePath.indexOf("?")
+  const hashIndex = filePath.indexOf("#")
+
+  let endIndex = filePath.length
+
+  if (queryIndex !== -1 && hashIndex !== -1) {
+    endIndex = Math.min(queryIndex, hashIndex)
+  } else if (queryIndex !== -1) {
+    endIndex = queryIndex
+  } else if (hashIndex !== -1) {
+    endIndex = hashIndex
+  }
+
+  return filePath.slice(0, endIndex)
+}
+
+const getExtension = (filePath: string) => {
+  const normalizedPath = stripQueryAndHash(filePath)
+  const lastDotIndex = normalizedPath.lastIndexOf(".")
+
+  if (lastDotIndex === -1) {
+    return ""
+  }
+
+  const lastSlashIndex = Math.max(
+    normalizedPath.lastIndexOf("/"),
+    normalizedPath.lastIndexOf("\\"),
+  )
+
+  if (lastSlashIndex > lastDotIndex) {
+    return ""
+  }
+
+  return normalizedPath.slice(lastDotIndex).toLowerCase()
+}
+
+const getTransformsForFilePath = (filePath: string) => {
+  const extension = getExtension(filePath)
+
+  const transforms: SucraseTransform[] = ["imports"]
+
+  if (TS_EXTENSIONS.has(extension)) {
+    transforms.unshift("typescript")
+  }
+
+  if (JSX_EXTENSIONS.has(extension)) {
+    transforms.push("jsx")
+  }
+
+  return transforms
+}
+
+export const transformWithSucrase = (code: string, filePath: string) => {
+  const transforms = getTransformsForFilePath(filePath)
+  const { code: transformedCode } = transform(code, {
+    filePath,
+    production: true,
+    transforms,
+  })
+
+  return transformedCode
+}


### PR DESCRIPTION
## Summary
- replace the worker-side Babel transforms with a shared Sucrase helper for TypeScript/JSX modules
- add Sucrase to the toolchain configuration and drop the Babel standalone dependency
- update the README to mention Sucrase instead of Babel

## Testing
- bunx tsc --noEmit
- bun test tests *(fails: requires remote @tsci/* snippet fetches and npm CDN access that return Forbidden in this environment)*
- bun run format

Related to: #1095

------
https://chatgpt.com/codex/tasks/task_b_68cd968eb590832e857e911032cc76a9