### PR TITLE
Fetch kicad_mod text instead of decoding data URI

### DIFF
--- a/lib/getPlatformConfig.ts
+++ b/lib/getPlatformConfig.ts
@@ -28,9 +28,8 @@ export const getPlatformConfig = (): PlatformConfig => ({
   footprintFileParserMap: {
     kicad_mod: {
       loadFromUrl: async (url: string) => {
-        const kicadJson = await parseKicadModToCircuitJson(
-          atob(url.replace("data:text/plain;base64,", "")),
-        )
+        const kicadContent = await fetch(url).then((res) => res.text())
+        const kicadJson = await parseKicadModToCircuitJson(kicadContent)
         return {
           footprintCircuitJson: Array.isArray(kicadJson)
             ? kicadJson

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@tscircuit/checks": "^0.0.75",
     "@tscircuit/circuit-json-flex": "^0.0.3",
     "@tscircuit/circuit-json-util": "^0.0.67",
-    "@tscircuit/core": "^0.0.751",
+    "@tscircuit/core": "^0.0.753",
     "@tscircuit/footprinter": "^0.0.236",
     "@tscircuit/import-snippet": "^0.0.4",
     "@tscircuit/infgrid-ijump-astar": "^0.0.33",


### PR DESCRIPTION
Previously loadFromUrl assumed a base64 data URI. This fixes parsing for normal URLs and supports remote footprints.

ref https://github.com/tscircuit/core/pull/1408