### PR TITLE
feat: resolve tsconfig path aliases

### DIFF
--- a/lib/utils/tsconfig-paths.ts
+++ b/lib/utils/tsconfig-paths.ts
@@ -1,0 +1,218 @@
+import { dirname } from "./dirname"
+import { normalizeFilePath } from "lib/runner/normalizeFsMap"
+
+const TS_CONFIG_FILENAMES = ["tsconfig.json", "tsconfig.base.json"]
+
+interface TsconfigPathEntry {
+  pattern: string
+  regex: RegExp
+  targets: string[]
+}
+
+export interface TsconfigPathsConfig {
+  absoluteBaseUrl: string
+  entries: TsconfigPathEntry[]
+}
+
+function stripJsonComments(input: string): string {
+  let output = ""
+  let inString = false
+  let stringQuote: string | null = null
+  let inSingleLineComment = false
+  let inMultiLineComment = false
+  let previousChar = ""
+
+  for (let i = 0; i < input.length; i++) {
+    const char = input[i]
+    const nextChar = input[i + 1]
+
+    if (inSingleLineComment) {
+      if (char === "\n") {
+        inSingleLineComment = false
+        output += char
+      }
+      continue
+    }
+
+    if (inMultiLineComment) {
+      if (char === "*" && nextChar === "/") {
+        inMultiLineComment = false
+        i += 1
+      }
+      continue
+    }
+
+    if (inString) {
+      output += char
+      if (char === stringQuote && previousChar !== "\\") {
+        inString = false
+        stringQuote = null
+      }
+      previousChar = char
+      continue
+    }
+
+    if (char === '"' || char === "'") {
+      inString = true
+      stringQuote = char
+      output += char
+      previousChar = char
+      continue
+    }
+
+    if (char === "/" && nextChar === "/") {
+      inSingleLineComment = true
+      i += 1
+      continue
+    }
+
+    if (char === "/" && nextChar === "*") {
+      inMultiLineComment = true
+      i += 1
+      continue
+    }
+
+    output += char
+    previousChar = char
+  }
+
+  return output
+}
+
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+function joinPaths(...segments: string[]): string {
+  const parts: string[] = []
+
+  for (const segment of segments) {
+    if (!segment) continue
+    const normalizedSegment = segment.replace(/\\/g, "/")
+    const tokens = normalizedSegment.split("/")
+
+    for (const token of tokens) {
+      if (!token || token === ".") continue
+      if (token === "..") {
+        if (parts.length > 0 && parts[parts.length - 1] !== "..") {
+          parts.pop()
+        } else {
+          parts.push("..")
+        }
+      } else {
+        parts.push(token)
+      }
+    }
+  }
+
+  return parts.join("/")
+}
+
+function applyStarMatches(target: string, matches: string[]): string {
+  const segments = target.split("*")
+  if (segments.length === 1) return target
+
+  let result = ""
+  for (let i = 0; i < segments.length; i++) {
+    result += segments[i]
+    if (i < matches.length) {
+      result += matches[i]
+    }
+  }
+
+  return result
+}
+
+function patternToRegex(pattern: string): RegExp {
+  const escapedSegments = pattern.split("*").map(escapeRegExp)
+  const regexPattern = `^${escapedSegments.join("(.+)")}$`
+  return new RegExp(regexPattern)
+}
+
+export function createTsconfigPathsConfig(
+  fsMap: Record<string, string>,
+): TsconfigPathsConfig | null {
+  let tsconfigPath: string | undefined
+
+  for (const candidate of TS_CONFIG_FILENAMES) {
+    if (candidate in fsMap) {
+      tsconfigPath = candidate
+      break
+    }
+  }
+
+  if (!tsconfigPath) {
+    tsconfigPath = Object.keys(fsMap).find((path) =>
+      path.endsWith("tsconfig.json"),
+    )
+  }
+
+  if (!tsconfigPath) return null
+
+  const tsconfigContent = fsMap[tsconfigPath]
+  if (!tsconfigContent) return null
+
+  let parsed: any
+  try {
+    parsed = JSON.parse(stripJsonComments(tsconfigContent))
+  } catch (error) {
+    console.warn("Failed to parse tsconfig for path mappings", error)
+    return null
+  }
+
+  const compilerOptions = parsed?.compilerOptions
+  if (!compilerOptions) return null
+
+  const paths = compilerOptions.paths as Record<string, string[] | undefined>
+  if (!paths) return null
+
+  const tsconfigDir = dirname(tsconfigPath)
+  const normalizedTsconfigDir = tsconfigDir === "." ? "" : tsconfigDir
+
+  const absoluteBaseUrl = joinPaths(
+    normalizedTsconfigDir,
+    compilerOptions.baseUrl ?? "",
+  )
+
+  const entries: TsconfigPathEntry[] = []
+
+  for (const [pattern, targetList] of Object.entries(paths)) {
+    if (!targetList || !Array.isArray(targetList) || targetList.length === 0)
+      continue
+
+    entries.push({
+      pattern,
+      regex: patternToRegex(pattern),
+      targets: targetList.map((target) => normalizeFilePath(target)),
+    })
+  }
+
+  if (entries.length === 0) return null
+
+  return {
+    absoluteBaseUrl,
+    entries,
+  }
+}
+
+export function resolveWithTsconfigPaths(
+  importPath: string,
+  config: TsconfigPathsConfig,
+): string[] {
+  const normalizedImportPath = normalizeFilePath(importPath)
+  const resolvedPaths: string[] = []
+
+  for (const entry of config.entries) {
+    const match = normalizedImportPath.match(entry.regex)
+    if (!match) continue
+
+    const starMatches = match.slice(1)
+    for (const target of entry.targets) {
+      const substitutedTarget = applyStarMatches(target, starMatches)
+      const candidatePath = joinPaths(config.absoluteBaseUrl, substitutedTarget)
+      resolvedPaths.push(normalizeFilePath(candidatePath))
+    }
+  }
+
+  return resolvedPaths
+}

--- a/tests/features/tsconfig-paths/tsconfig-paths-resolution.test.tsx
+++ b/tests/features/tsconfig-paths/tsconfig-paths-resolution.test.tsx
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test"
+import { createCircuitWebWorker } from "lib"
+import { repoFileUrl } from "tests/fixtures/resourcePaths"
+
+const TS_CONFIG = `{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@components/*": ["components/*"],
+      "@helpers": ["helpers/index.ts"]
+    }
+  }
+}`
+
+test("resolves imports using tsconfig path aliases", async () => {
+  const circuitWebWorkerPromise = createCircuitWebWorker({
+    webWorkerUrl: repoFileUrl("dist/webworker/entrypoint.js").href,
+  })
+
+  const worker = await circuitWebWorkerPromise
+
+  await worker.executeWithFsMap({
+    entrypoint: "index.tsx",
+    fsMap: {
+      "tsconfig.json": TS_CONFIG,
+      "index.tsx": `
+import { BoardWithResistor } from "@components/BoardWithResistor"
+
+circuit.add(<BoardWithResistor />)
+      `,
+      "components/BoardWithResistor.tsx": `
+import { resistorName } from "@helpers"
+
+export const BoardWithResistor = () => (
+  <board width="10mm" height="10mm">
+    <resistor name={resistorName} resistance="1k" footprint="0402" />
+  </board>
+)
+      `,
+      "helpers/index.ts": `
+export const resistorName = "R_ALIAS"
+      `,
+    },
+  })
+
+  await worker.renderUntilSettled()
+
+  const circuitJson = await worker.getCircuitJson()
+  const resistor = circuitJson.find(
+    (element) =>
+      element.type === "source_component" && element.name === "R_ALIAS",
+  )
+
+  expect(resistor).toBeDefined()
+
+  await worker.kill()
+})

--- a/webworker/entrypoint.ts
+++ b/webworker/entrypoint.ts
@@ -15,6 +15,7 @@ import { normalizeFsMap } from "lib/runner/normalizeFsMap"
 import type { RootCircuit } from "@tscircuit/core"
 import { setupDefaultEntrypointIfNeeded } from "lib/runner/setupDefaultEntrypointIfNeeded"
 import { setupFetchProxy } from "./fetchProxy"
+import { createTsconfigPathsConfig } from "lib/utils/tsconfig-paths"
 
 globalThis.React = React
 setupFetchProxy()
@@ -122,6 +123,9 @@ const webWorkerApi = {
     })
     bindEventListeners(executionContext.circuit)
     executionContext.fsMap = normalizeFsMap(opts.fsMap)
+    executionContext.tsconfigPaths = createTsconfigPathsConfig(
+      executionContext.fsMap,
+    )
     if (!executionContext.fsMap[entrypoint]) {
       throw new Error(`Entrypoint "${opts.entrypoint}" not found`)
     }
@@ -146,6 +150,7 @@ const webWorkerApi = {
     })
     bindEventListeners(executionContext.circuit)
     executionContext.fsMap["entrypoint.tsx"] = code
+    executionContext.tsconfigPaths = null
     ;(globalThis as any).__tscircuit_circuit = executionContext.circuit
 
     await importEvalPath("./entrypoint.tsx", executionContext)
@@ -162,6 +167,7 @@ const webWorkerApi = {
       debugNamespace,
     })
     bindEventListeners(executionContext.circuit)
+    executionContext.tsconfigPaths = null
     ;(globalThis as any).__tscircuit_circuit = executionContext.circuit
 
     let element: any

--- a/webworker/eval-compiled-js.ts
+++ b/webworker/eval-compiled-js.ts
@@ -1,12 +1,17 @@
 import { resolveFilePath } from "lib/runner/resolveFilePath"
+import type { TsconfigPathsConfig } from "lib/utils/tsconfig-paths"
 
 export function evalCompiledJs(
   compiledCode: string,
   preSuppliedImports: Record<string, any>,
   cwd?: string,
+  tsconfigPaths?: TsconfigPathsConfig | null,
 ) {
   ;(globalThis as any).__tscircuit_require = (name: string) => {
-    const resolvedFilePath = resolveFilePath(name, preSuppliedImports, cwd)
+    const resolvedFilePath = resolveFilePath(name, preSuppliedImports, {
+      cwd,
+      tsconfigPaths,
+    })
 
     const hasResolvedFilePath =
       resolvedFilePath && preSuppliedImports[resolvedFilePath]

--- a/webworker/execution-context.ts
+++ b/webworker/execution-context.ts
@@ -6,6 +6,7 @@ import * as tscircuitMathUtils from "@tscircuit/math-utils"
 import type { PlatformConfig } from "@tscircuit/props"
 import { getPlatformConfig } from "lib/getPlatformConfig"
 import Debug from "debug"
+import type { TsconfigPathsConfig } from "lib/utils/tsconfig-paths"
 
 const debug = Debug("tsci:eval:execution-context")
 
@@ -14,6 +15,7 @@ export interface ExecutionContext extends WebWorkerConfiguration {
   entrypoint: string
   preSuppliedImports: Record<string, any>
   circuit: RootCircuit
+  tsconfigPaths: TsconfigPathsConfig | null
 }
 
 export function createExecutionContext(
@@ -59,6 +61,7 @@ export function createExecutionContext(
       "@tscircuit/props": {},
     },
     circuit,
+    tsconfigPaths: null,
     ...webWorkerConfiguration,
   }
 }

--- a/webworker/import-eval-path.ts
+++ b/webworker/import-eval-path.ts
@@ -45,11 +45,10 @@ export async function importEvalPath(
     return
   }
 
-  const resolvedLocalImportPath = resolveFilePath(
-    importName,
-    ctx.fsMap,
-    opts.cwd,
-  )
+  const resolvedLocalImportPath = resolveFilePath(importName, ctx.fsMap, {
+    cwd: opts.cwd,
+    tsconfigPaths: ctx.tsconfigPaths,
+  })
   if (resolvedLocalImportPath) {
     return importLocalFile(resolvedLocalImportPath, ctx, depth)
   }

--- a/webworker/import-local-file.ts
+++ b/webworker/import-local-file.ts
@@ -24,7 +24,9 @@ export const importLocalFile = async (
 
   const { fsMap, preSuppliedImports } = ctx
 
-  const fsPath = resolveFilePathOrThrow(importName, fsMap)
+  const fsPath = resolveFilePathOrThrow(importName, fsMap, {
+    tsconfigPaths: ctx.tsconfigPaths,
+  })
   debug("fsPath:", fsPath)
   if (!ctx.fsMap[fsPath]) {
     debug("fsPath not found in fsMap:", fsPath)
@@ -67,6 +69,7 @@ export const importLocalFile = async (
         transformedCode,
         preSuppliedImports,
         dirname(fsPath),
+        ctx.tsconfigPaths,
       )
       debug("importRunResult:", {
         fsPath,
@@ -84,6 +87,7 @@ export const importLocalFile = async (
       transformWithSucrase(fileContent, fsPath),
       preSuppliedImports,
       dirname(fsPath),
+      ctx.tsconfigPaths,
     ).exports
   } else {
     throw new Error(

--- a/webworker/import-npm-package.ts
+++ b/webworker/import-npm-package.ts
@@ -67,6 +67,7 @@ export async function importNpmPackage(
       transformedCode,
       preSuppliedImports,
       cwd,
+      ctx.tsconfigPaths,
     ).exports
     preSuppliedImports[importName] = exports
     preSuppliedImports[finalImportName] = exports

--- a/webworker/import-snippet.ts
+++ b/webworker/import-snippet.ts
@@ -23,6 +23,8 @@ export async function importSnippet(
     preSuppliedImports[importName] = evalCompiledJs(
       cjs!,
       preSuppliedImports,
+      undefined,
+      ctx.tsconfigPaths,
     ).exports
   } catch (e) {
     console.error("Error importing snippet", e)


### PR DESCRIPTION
## Summary
- add utilities to parse tsconfig baseUrl and paths entries
- thread parsed path mappings through resolveFilePath and worker imports to support alias lookups
- add a regression test covering tsconfig path alias resolution via CircuitWebWorker

## Testing
- bunx tsc --noEmit
- bun test tests/features/tsconfig-paths/tsconfig-paths-resolution.test.tsx

------
https://chatgpt.com/codex/tasks/task_b_68e6fce7fe18832e89ccfd5af5e60c2b