### PR TITLE
feat: Add support for TypeScript path mappings

### DIFF
--- a/lib/runner/CircuitRunner.ts
+++ b/lib/runner/CircuitRunner.ts
@@ -4,7 +4,7 @@ import type {
   CircuitRunnerConfiguration,
 } from "lib/shared/types"
 import type { PlatformConfig } from "@tscircuit/props"
-import { createExecutionContext } from "../../webworker/execution-context"
+import { createExecutionContext } from "webworker/execution-context"
 import { normalizeFsMap } from "./normalizeFsMap"
 import type { RootCircuit } from "@tscircuit/core"
 import * as React from "react"

--- a/lib/runner/index.ts
+++ b/lib/runner/index.ts
@@ -1,4 +1,4 @@
 export * from "./CircuitRunner"
 export * from "./runTscircuitCode"
 export * from "./runTscircuitModule"
-export * from "../shared/static-asset-extensions"
+export * from "lib/shared/static-asset-extensions"

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,1 +1,2 @@
 export * from "./get-imports-from-code"
+export * from "./parse-tsconfig-paths"

--- a/lib/utils/parse-tsconfig-paths.ts
+++ b/lib/utils/parse-tsconfig-paths.ts
@@ -1,0 +1,132 @@
+import Debug from "debug"
+
+const debug = Debug("tsci:eval:parse-tsconfig-paths")
+
+export interface TsconfigPaths {
+  baseUrl?: string
+  paths?: Record<string, string[]>
+}
+
+/**
+ * Parse tsconfig.json from fsMap to extract path mappings
+ */
+export function parseTsconfigPaths(
+  fsMap: Record<string, string>,
+): TsconfigPaths | null {
+  // Try common tsconfig locations
+  const possibleTsconfigPaths = [
+    "tsconfig.json",
+    "./tsconfig.json",
+    "src/tsconfig.json",
+    "./src/tsconfig.json",
+  ]
+
+  for (const tsconfigPath of possibleTsconfigPaths) {
+    const content = fsMap[tsconfigPath]
+    if (content) {
+      try {
+        // Remove comments from JSON (tsconfig allows comments)
+        const jsonContent = removeJsonComments(content)
+        const tsconfig = JSON.parse(jsonContent)
+
+        const compilerOptions = tsconfig.compilerOptions
+        if (!compilerOptions) {
+          continue
+        }
+
+        const result: TsconfigPaths = {}
+
+        if (compilerOptions.baseUrl) {
+          result.baseUrl = compilerOptions.baseUrl
+        }
+
+        if (compilerOptions.paths) {
+          result.paths = compilerOptions.paths
+        }
+
+        debug("Parsed tsconfig paths:", result)
+        return result
+      } catch (error: any) {
+        debug(`Failed to parse tsconfig at ${tsconfigPath}:`, error.message)
+      }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Remove single-line and multi-line comments from JSON string
+ */
+function removeJsonComments(jsonString: string): string {
+  // Remove single-line comments (// ...)
+  let result = jsonString.replace(/\/\/.*$/gm, "")
+
+  // Remove multi-line comments (/* ... */)
+  result = result.replace(/\/\*[\s\S]*?\*\//g, "")
+
+  return result
+}
+
+/**
+ * Resolve an import path using tsconfig path mappings
+ * @param importPath The import path to resolve (e.g., "@lib/utils")
+ * @param tsconfigPaths The parsed tsconfig paths
+ * @param cwd Current working directory (relative to project root)
+ * @returns Array of possible file paths to try, or null if no match
+ */
+export function resolveTsconfigPath(
+  importPath: string,
+  tsconfigPaths: TsconfigPaths | null,
+  cwd?: string,
+): string[] | null {
+  if (!tsconfigPaths?.paths) {
+    return null
+  }
+
+  const { baseUrl = ".", paths } = tsconfigPaths
+
+  // Find matching path pattern
+  for (const [pattern, replacements] of Object.entries(paths)) {
+    // Convert tsconfig pattern to regex
+    // e.g., "@lib/*" becomes "^@lib/(.*)$"
+    const regexPattern = pattern
+      .replace(/\./g, "\\.")
+      .replace(/\*/g, "(.*)")
+      .replace(/\$/g, "\\$")
+
+    const regex = new RegExp(`^${regexPattern}$`)
+    const match = importPath.match(regex)
+
+    if (match) {
+      debug(`Matched pattern "${pattern}" for import "${importPath}"`)
+
+      // Generate possible paths from replacements
+      const possiblePaths: string[] = []
+
+      for (const replacement of replacements) {
+        let resolvedPath = replacement
+
+        // Replace wildcards with captured groups
+        for (let i = 1; i < match.length; i++) {
+          resolvedPath = resolvedPath.replace("*", match[i])
+        }
+
+        // Apply baseUrl
+        if (baseUrl && baseUrl !== ".") {
+          resolvedPath = `${baseUrl}/${resolvedPath}`
+        }
+
+        // Normalize path (remove leading ./)
+        resolvedPath = resolvedPath.replace(/^\.\//, "")
+
+        possiblePaths.push(resolvedPath)
+        debug(`Generated possible path: ${resolvedPath}`)
+      }
+
+      return possiblePaths
+    }
+  }
+
+  return null
+}

--- a/tests/examples/example21-tsconfig-paths.test.tsx
+++ b/tests/examples/example21-tsconfig-paths.test.tsx
@@ -1,0 +1,417 @@
+import { createCircuitWebWorker } from "lib"
+import { expect, test } from "bun:test"
+
+test("tsconfig paths - basic alias resolution", async () => {
+  const circuitWebWorker = await createCircuitWebWorker({
+    webWorkerUrl: new URL("../../webworker/entrypoint.ts", import.meta.url),
+  })
+
+  await circuitWebWorker.executeWithFsMap({
+    fsMap: {
+      "tsconfig.json": `
+        {
+          "compilerOptions": {
+            "baseUrl": ".",
+            "paths": {
+              "@lib/*": ["lib/*"],
+              "@components/*": ["src/components/*"]
+            }
+          }
+        }
+      `,
+      "entrypoint.tsx": `
+        import { MyResistor } from "@lib/resistor"
+        import { MyLed } from "@components/led"
+        
+        circuit.add(
+          <board width="10mm" height="10mm">
+            <MyResistor name="R1" resistance="10k" />
+            <MyLed name="LED1" />
+          </board>
+        )
+      `,
+      "lib/resistor.tsx": `
+        export const MyResistor = ({ name, resistance }) => {
+          return <resistor name={name} resistance={resistance} />
+        }
+      `,
+      "src/components/led.tsx": `
+        import { RedLed } from "@tsci/seveibar.red-led"
+        
+        export const MyLed = ({ name }) => {
+          return <RedLed name={name} />
+        }
+      `,
+    },
+    entrypoint: "entrypoint.tsx",
+  })
+
+  await circuitWebWorker.renderUntilSettled()
+
+  const circuitJson = await circuitWebWorker.getCircuitJson()
+
+  const resistor = circuitJson.find((el: any) => el.name === "R1")
+  expect(resistor?.type).toBe("source_component")
+
+  const led = circuitJson.find((el: any) => el.name === "LED1")
+  expect(led?.type).toBe("source_component")
+
+  await circuitWebWorker.kill()
+})
+
+test("tsconfig paths - wildcard pattern", async () => {
+  const circuitWebWorker = await createCircuitWebWorker({
+    webWorkerUrl: new URL("../../webworker/entrypoint.ts", import.meta.url),
+  })
+
+  await circuitWebWorker.executeWithFsMap({
+    fsMap: {
+      "tsconfig.json": `
+        {
+          "compilerOptions": {
+            "baseUrl": ".",
+            "paths": {
+              "@utils/*": ["src/utils/*"]
+            }
+          }
+        }
+      `,
+      "entrypoint.tsx": `
+        import { calculateValue } from "@utils/calculations"
+        
+        const resistance = calculateValue("10k")
+        
+        circuit.add(
+          <board width="10mm" height="10mm">
+            <resistor name="R1" resistance={resistance} />
+          </board>
+        )
+      `,
+      "src/utils/calculations.ts": `
+        export function calculateValue(value: string): string {
+          return value
+        }
+      `,
+    },
+    entrypoint: "entrypoint.tsx",
+  })
+
+  await circuitWebWorker.renderUntilSettled()
+
+  const circuitJson = await circuitWebWorker.getCircuitJson()
+
+  const resistor = circuitJson.find((el: any) => el.name === "R1")
+  expect(resistor?.type).toBe("source_component")
+
+  await circuitWebWorker.kill()
+})
+
+test("tsconfig paths - multiple path mappings for same alias", async () => {
+  const circuitWebWorker = await createCircuitWebWorker({
+    webWorkerUrl: new URL("../../webworker/entrypoint.ts", import.meta.url),
+  })
+
+  await circuitWebWorker.executeWithFsMap({
+    fsMap: {
+      "tsconfig.json": `
+        {
+          "compilerOptions": {
+            "baseUrl": ".",
+            "paths": {
+              "@components/*": ["src/components/*", "lib/components/*"]
+            }
+          }
+        }
+      `,
+      "entrypoint.tsx": `
+        import { MyResistor } from "@components/resistor"
+        
+        circuit.add(
+          <board width="10mm" height="10mm">
+            <MyResistor name="R1" resistance="10k" />
+          </board>
+        )
+      `,
+      "lib/components/resistor.tsx": `
+        export const MyResistor = ({ name, resistance }) => {
+          return <resistor name={name} resistance={resistance} />
+        }
+      `,
+    },
+    entrypoint: "entrypoint.tsx",
+  })
+
+  await circuitWebWorker.renderUntilSettled()
+
+  const circuitJson = await circuitWebWorker.getCircuitJson()
+
+  const resistor = circuitJson.find((el: any) => el.name === "R1")
+  expect(resistor?.type).toBe("source_component")
+
+  await circuitWebWorker.kill()
+})
+
+test("tsconfig paths - with baseUrl and nested imports", async () => {
+  const circuitWebWorker = await createCircuitWebWorker({
+    webWorkerUrl: new URL("../../webworker/entrypoint.ts", import.meta.url),
+  })
+
+  await circuitWebWorker.executeWithFsMap({
+    fsMap: {
+      "tsconfig.json": `
+        {
+          "compilerOptions": {
+            "baseUrl": "src",
+            "paths": {
+              "@lib/*": ["lib/*"]
+            }
+          }
+        }
+      `,
+      "entrypoint.tsx": `
+        import { MyComponent } from "@lib/components/mycomponent"
+        
+        circuit.add(
+          <board width="10mm" height="10mm">
+            <MyComponent name="C1" />
+          </board>
+        )
+      `,
+      "src/lib/components/mycomponent.tsx": `
+        export const MyComponent = ({ name }) => {
+          return <resistor name={name} resistance="10k" />
+        }
+      `,
+    },
+    entrypoint: "entrypoint.tsx",
+  })
+
+  await circuitWebWorker.renderUntilSettled()
+
+  const circuitJson = await circuitWebWorker.getCircuitJson()
+
+  const component = circuitJson.find((el: any) => el.name === "C1")
+  expect(component?.type).toBe("source_component")
+
+  await circuitWebWorker.kill()
+})
+
+test("tsconfig paths - exact match without wildcard", async () => {
+  const circuitWebWorker = await createCircuitWebWorker({
+    webWorkerUrl: new URL("../../webworker/entrypoint.ts", import.meta.url),
+  })
+
+  await circuitWebWorker.executeWithFsMap({
+    fsMap: {
+      "tsconfig.json": `
+        {
+          "compilerOptions": {
+            "baseUrl": ".",
+            "paths": {
+              "@utils": ["src/utils/index"]
+            }
+          }
+        }
+      `,
+      "entrypoint.tsx": `
+        import { getValue } from "@utils"
+        
+        const value = getValue()
+        
+        circuit.add(
+          <board width="10mm" height="10mm">
+            <resistor name={value} resistance="10k" />
+          </board>
+        )
+      `,
+      "src/utils/index.ts": `
+        export function getValue(): string {
+          return "R1"
+        }
+      `,
+    },
+    entrypoint: "entrypoint.tsx",
+  })
+
+  await circuitWebWorker.renderUntilSettled()
+
+  const circuitJson = await circuitWebWorker.getCircuitJson()
+
+  const resistor = circuitJson.find((el: any) => el.name === "R1")
+  expect(resistor?.type).toBe("source_component")
+
+  await circuitWebWorker.kill()
+})
+
+test("tsconfig paths - with comments in tsconfig", async () => {
+  const circuitWebWorker = await createCircuitWebWorker({
+    webWorkerUrl: new URL("../../webworker/entrypoint.ts", import.meta.url),
+  })
+
+  await circuitWebWorker.executeWithFsMap({
+    fsMap: {
+      "tsconfig.json": `
+        {
+          // Compiler options
+          "compilerOptions": {
+            "baseUrl": ".",
+            /* Path mappings for easier imports */
+            "paths": {
+              "@components/*": ["src/components/*"] // Component paths
+            }
+          }
+        }
+      `,
+      "entrypoint.tsx": `
+        import { MyResistor } from "@components/resistor"
+        
+        circuit.add(
+          <board width="10mm" height="10mm">
+            <MyResistor name="R1" resistance="10k" />
+          </board>
+        )
+      `,
+      "src/components/resistor.tsx": `
+        export const MyResistor = ({ name, resistance }) => {
+          return <resistor name={name} resistance={resistance} />
+        }
+      `,
+    },
+    entrypoint: "entrypoint.tsx",
+  })
+
+  await circuitWebWorker.renderUntilSettled()
+
+  const circuitJson = await circuitWebWorker.getCircuitJson()
+
+  const resistor = circuitJson.find((el: any) => el.name === "R1")
+  expect(resistor?.type).toBe("source_component")
+
+  await circuitWebWorker.kill()
+})
+
+test("tsconfig paths - fallback to relative imports", async () => {
+  const circuitWebWorker = await createCircuitWebWorker({
+    webWorkerUrl: new URL("../../webworker/entrypoint.ts", import.meta.url),
+  })
+
+  await circuitWebWorker.executeWithFsMap({
+    fsMap: {
+      "tsconfig.json": `
+        {
+          "compilerOptions": {
+            "baseUrl": ".",
+            "paths": {
+              "@lib/*": ["lib/*"]
+            }
+          }
+        }
+      `,
+      "entrypoint.tsx": `
+        import { MyResistor } from "@lib/resistor"
+        import { MyLed } from "./led"
+        
+        circuit.add(
+          <board width="10mm" height="10mm">
+            <MyResistor name="R1" resistance="10k" />
+            <MyLed name="LED1" />
+          </board>
+        )
+      `,
+      "lib/resistor.tsx": `
+        export const MyResistor = ({ name, resistance }) => {
+          return <resistor name={name} resistance={resistance} />
+        }
+      `,
+      "led.tsx": `
+        import { RedLed } from "@tsci/seveibar.red-led"
+        
+        export const MyLed = ({ name }) => {
+          return <RedLed name={name} />
+        }
+      `,
+    },
+    entrypoint: "entrypoint.tsx",
+  })
+
+  await circuitWebWorker.renderUntilSettled()
+
+  const circuitJson = await circuitWebWorker.getCircuitJson()
+
+  const resistor = circuitJson.find((el: any) => el.name === "R1")
+  expect(resistor?.type).toBe("source_component")
+
+  const led = circuitJson.find((el: any) => el.name === "LED1")
+  expect(led?.type).toBe("source_component")
+
+  await circuitWebWorker.kill()
+})
+
+test("tsconfig paths - nested component imports with aliases", async () => {
+  const circuitWebWorker = await createCircuitWebWorker({
+    webWorkerUrl: new URL("../../webworker/entrypoint.ts", import.meta.url),
+  })
+
+  await circuitWebWorker.executeWithFsMap({
+    fsMap: {
+      "tsconfig.json": `
+        {
+          "compilerOptions": {
+            "baseUrl": ".",
+            "paths": {
+              "@lib/*": ["lib/*"],
+              "@utils/*": ["utils/*"]
+            }
+          }
+        }
+      `,
+      "entrypoint.tsx": `
+        import { PowerSupply } from "@lib/powersupply"
+        
+        circuit.add(
+          <board width="20mm" height="20mm">
+            <PowerSupply name="PS1" />
+          </board>
+        )
+      `,
+      "lib/powersupply.tsx": `
+        import { Resistor } from "@lib/resistor"
+        import { calculateResistance } from "@utils/calc"
+        
+        export const PowerSupply = ({ name }) => {
+          const resistance = calculateResistance(5, 3.3)
+          return (
+            <group>
+              <Resistor name={\`\${name}_R1\`} resistance={resistance} />
+              <resistor name={\`\${name}_R2\`} resistance="1k" />
+            </group>
+          )
+        }
+      `,
+      "lib/resistor.tsx": `
+        export const Resistor = ({ name, resistance }) => {
+          return <resistor name={name} resistance={resistance} />
+        }
+      `,
+      "utils/calc.ts": `
+        export function calculateResistance(v1: number, v2: number): string {
+          const ohms = Math.round((v1 - v2) / 0.02)
+          return \`\${ohms}ohm\`
+        }
+      `,
+    },
+    entrypoint: "entrypoint.tsx",
+  })
+
+  await circuitWebWorker.renderUntilSettled()
+
+  const circuitJson = await circuitWebWorker.getCircuitJson()
+
+  const resistor1 = circuitJson.find((el: any) => el.name === "PS1_R1")
+  expect(resistor1?.type).toBe("source_component")
+
+  const resistor2 = circuitJson.find((el: any) => el.name === "PS1_R2")
+  expect(resistor2?.type).toBe("source_component")
+
+  await circuitWebWorker.kill()
+})

--- a/tests/util-fns/parse-tsconfig-paths.test.ts
+++ b/tests/util-fns/parse-tsconfig-paths.test.ts
@@ -1,0 +1,205 @@
+import { expect, test } from "bun:test"
+import {
+  parseTsconfigPaths,
+  resolveTsconfigPath,
+} from "lib/utils/parse-tsconfig-paths"
+
+test("parseTsconfigPaths - basic parsing", () => {
+  const fsMap = {
+    "tsconfig.json": `
+      {
+        "compilerOptions": {
+          "baseUrl": ".",
+          "paths": {
+            "@lib/*": ["lib/*"],
+            "@components/*": ["src/components/*"]
+          }
+        }
+      }
+    `,
+  }
+
+  const result = parseTsconfigPaths(fsMap)
+  expect(result).toEqual({
+    baseUrl: ".",
+    paths: {
+      "@lib/*": ["lib/*"],
+      "@components/*": ["src/components/*"],
+    },
+  })
+})
+
+test("parseTsconfigPaths - with comments", () => {
+  const fsMap = {
+    "tsconfig.json": `
+      {
+        // TypeScript configuration
+        "compilerOptions": {
+          "baseUrl": ".",
+          /* Path mappings */
+          "paths": {
+            "@lib/*": ["lib/*"] // Library files
+          }
+        }
+      }
+    `,
+  }
+
+  const result = parseTsconfigPaths(fsMap)
+  expect(result).toEqual({
+    baseUrl: ".",
+    paths: {
+      "@lib/*": ["lib/*"],
+    },
+  })
+})
+
+test("parseTsconfigPaths - no paths defined", () => {
+  const fsMap = {
+    "tsconfig.json": `
+      {
+        "compilerOptions": {
+          "baseUrl": "."
+        }
+      }
+    `,
+  }
+
+  const result = parseTsconfigPaths(fsMap)
+  expect(result).toEqual({
+    baseUrl: ".",
+  })
+})
+
+test("parseTsconfigPaths - no tsconfig.json", () => {
+  const fsMap = {
+    "entrypoint.tsx": "const a = 1",
+  }
+
+  const result = parseTsconfigPaths(fsMap)
+  expect(result).toBeNull()
+})
+
+test("parseTsconfigPaths - finds tsconfig in src folder", () => {
+  const fsMap = {
+    "src/tsconfig.json": `
+      {
+        "compilerOptions": {
+          "baseUrl": "src",
+          "paths": {
+            "@utils/*": ["utils/*"]
+          }
+        }
+      }
+    `,
+  }
+
+  const result = parseTsconfigPaths(fsMap)
+  expect(result).toEqual({
+    baseUrl: "src",
+    paths: {
+      "@utils/*": ["utils/*"],
+    },
+  })
+})
+
+test("resolveTsconfigPath - basic wildcard resolution", () => {
+  const tsconfigPaths = {
+    baseUrl: ".",
+    paths: {
+      "@lib/*": ["lib/*"],
+    },
+  }
+
+  const result = resolveTsconfigPath("@lib/utils", tsconfigPaths)
+  expect(result).toEqual(["lib/utils"])
+})
+
+test("resolveTsconfigPath - multiple path mappings", () => {
+  const tsconfigPaths = {
+    baseUrl: ".",
+    paths: {
+      "@components/*": ["src/components/*", "lib/components/*"],
+    },
+  }
+
+  const result = resolveTsconfigPath("@components/button", tsconfigPaths)
+  expect(result).toEqual(["src/components/button", "lib/components/button"])
+})
+
+test("resolveTsconfigPath - nested path", () => {
+  const tsconfigPaths = {
+    baseUrl: ".",
+    paths: {
+      "@lib/*": ["lib/*"],
+    },
+  }
+
+  const result = resolveTsconfigPath("@lib/components/button", tsconfigPaths)
+  expect(result).toEqual(["lib/components/button"])
+})
+
+test("resolveTsconfigPath - exact match without wildcard", () => {
+  const tsconfigPaths = {
+    baseUrl: ".",
+    paths: {
+      "@utils": ["src/utils/index"],
+    },
+  }
+
+  const result = resolveTsconfigPath("@utils", tsconfigPaths)
+  expect(result).toEqual(["src/utils/index"])
+})
+
+test("resolveTsconfigPath - with baseUrl other than root", () => {
+  const tsconfigPaths = {
+    baseUrl: "src",
+    paths: {
+      "@lib/*": ["lib/*"],
+    },
+  }
+
+  const result = resolveTsconfigPath("@lib/utils", tsconfigPaths)
+  expect(result).toEqual(["src/lib/utils"])
+})
+
+test("resolveTsconfigPath - no match", () => {
+  const tsconfigPaths = {
+    baseUrl: ".",
+    paths: {
+      "@lib/*": ["lib/*"],
+    },
+  }
+
+  const result = resolveTsconfigPath("@components/button", tsconfigPaths)
+  expect(result).toBeNull()
+})
+
+test("resolveTsconfigPath - null paths", () => {
+  const result = resolveTsconfigPath("@lib/utils", null)
+  expect(result).toBeNull()
+})
+
+test("resolveTsconfigPath - special characters in pattern", () => {
+  const tsconfigPaths = {
+    baseUrl: ".",
+    paths: {
+      "$lib/*": ["lib/*"],
+    },
+  }
+
+  const result = resolveTsconfigPath("$lib/utils", tsconfigPaths)
+  expect(result).toEqual(["lib/utils"])
+})
+
+test("resolveTsconfigPath - removes leading ./ from resolved paths", () => {
+  const tsconfigPaths = {
+    baseUrl: ".",
+    paths: {
+      "@lib/*": ["./lib/*"],
+    },
+  }
+
+  const result = resolveTsconfigPath("@lib/utils", tsconfigPaths)
+  expect(result).toEqual(["lib/utils"])
+})

--- a/webworker/entrypoint.ts
+++ b/webworker/entrypoint.ts
@@ -122,9 +122,11 @@ const webWorkerApi = {
     })
     bindEventListeners(executionContext.circuit)
     executionContext.fsMap = normalizeFsMap(opts.fsMap)
-    
+
     // Parse tsconfig paths if tsconfig.json exists in fsMap
-    const { parseTsconfigPaths } = await import("lib/utils/parse-tsconfig-paths")
+    const { parseTsconfigPaths } = await import(
+      "lib/utils/parse-tsconfig-paths"
+    )
     executionContext.tsconfigPaths = parseTsconfigPaths(executionContext.fsMap)
     if (!executionContext.fsMap[entrypoint]) {
       throw new Error(`Entrypoint "${opts.entrypoint}" not found`)

--- a/webworker/entrypoint.ts
+++ b/webworker/entrypoint.ts
@@ -122,6 +122,10 @@ const webWorkerApi = {
     })
     bindEventListeners(executionContext.circuit)
     executionContext.fsMap = normalizeFsMap(opts.fsMap)
+    
+    // Parse tsconfig paths if tsconfig.json exists in fsMap
+    const { parseTsconfigPaths } = await import("lib/utils/parse-tsconfig-paths")
+    executionContext.tsconfigPaths = parseTsconfigPaths(executionContext.fsMap)
     if (!executionContext.fsMap[entrypoint]) {
       throw new Error(`Entrypoint "${opts.entrypoint}" not found`)
     }

--- a/webworker/execution-context.ts
+++ b/webworker/execution-context.ts
@@ -5,6 +5,7 @@ import * as React from "react"
 import * as tscircuitMathUtils from "@tscircuit/math-utils"
 import type { PlatformConfig } from "@tscircuit/props"
 import { getPlatformConfig } from "lib/getPlatformConfig"
+import type { TsconfigPaths } from "lib/utils/parse-tsconfig-paths"
 import Debug from "debug"
 
 const debug = Debug("tsci:eval:execution-context")
@@ -14,6 +15,7 @@ export interface ExecutionContext extends WebWorkerConfiguration {
   entrypoint: string
   preSuppliedImports: Record<string, any>
   circuit: RootCircuit
+  tsconfigPaths?: TsconfigPaths | null
 }
 
 export function createExecutionContext(

--- a/webworker/import-eval-path.ts
+++ b/webworker/import-eval-path.ts
@@ -58,7 +58,8 @@ export async function importEvalPath(
       resolvedLocalImportPath !== importName &&
       preSuppliedImports[resolvedLocalImportPath]
     ) {
-      preSuppliedImports[importName] = preSuppliedImports[resolvedLocalImportPath]
+      preSuppliedImports[importName] =
+        preSuppliedImports[resolvedLocalImportPath]
     }
     return
   }

--- a/webworker/import-eval-path.ts
+++ b/webworker/import-eval-path.ts
@@ -49,9 +49,18 @@ export async function importEvalPath(
     importName,
     ctx.fsMap,
     opts.cwd,
+    ctx.tsconfigPaths,
   )
   if (resolvedLocalImportPath) {
-    return importLocalFile(resolvedLocalImportPath, ctx, depth)
+    await importLocalFile(resolvedLocalImportPath, ctx, depth)
+    // If the import was resolved using tsconfig paths, also register it under the original alias
+    if (
+      resolvedLocalImportPath !== importName &&
+      preSuppliedImports[resolvedLocalImportPath]
+    ) {
+      preSuppliedImports[importName] = preSuppliedImports[resolvedLocalImportPath]
+    }
+    return
   }
 
   // Try to resolve from node_modules

--- a/webworker/import-local-file.ts
+++ b/webworker/import-local-file.ts
@@ -24,7 +24,7 @@ export const importLocalFile = async (
 
   const { fsMap, preSuppliedImports } = ctx
 
-  const fsPath = resolveFilePathOrThrow(importName, fsMap)
+  const fsPath = resolveFilePathOrThrow(importName, fsMap, undefined, ctx.tsconfigPaths)
   debug("fsPath:", fsPath)
   if (!ctx.fsMap[fsPath]) {
     debug("fsPath not found in fsMap:", fsPath)

--- a/webworker/import-local-file.ts
+++ b/webworker/import-local-file.ts
@@ -24,7 +24,12 @@ export const importLocalFile = async (
 
   const { fsMap, preSuppliedImports } = ctx
 
-  const fsPath = resolveFilePathOrThrow(importName, fsMap, undefined, ctx.tsconfigPaths)
+  const fsPath = resolveFilePathOrThrow(
+    importName,
+    fsMap,
+    undefined,
+    ctx.tsconfigPaths,
+  )
   debug("fsPath:", fsPath)
   if (!ctx.fsMap[fsPath]) {
     debug("fsPath not found in fsMap:", fsPath)


### PR DESCRIPTION
## PR Description

Adds support for TypeScript `paths` configuration from `tsconfig.json`, enabling path aliases for cleaner imports.

### Key Files

- `lib/utils/parse-tsconfig-paths.ts`: Core parsing and resolution logic
- `lib/runner/resolveFilePath.ts`: File path resolution with tsconfig support
- `webworker/execution-context.ts`: Execution context with tsconfig paths
- `webworker/import-eval-path.ts`: Import resolution with alias registration
- `webworker/entrypoint.ts`: Automatic tsconfig parsing on initialization

## Testing

Added the following tests:

- Unit tests for path parsing and resolution (`tests/util-fns/parse-tsconfig-paths.test.ts`)
- Integration tests with various scenarios (`tests/examples/example21-tsconfig-paths.test.tsx`)

fixes #1204 
/claim #1204 