### PR TITLE
Improve entrypoint empty circuit error message

### DIFF
--- a/lib/utils/enhance-root-circuit-error.ts
+++ b/lib/utils/enhance-root-circuit-error.ts
@@ -1,0 +1,18 @@
+export const enhanceRootCircuitHasNoChildrenError = (
+  error: unknown,
+  entrypoint?: string,
+) => {
+  if (
+    error instanceof Error &&
+    entrypoint &&
+    error.message.includes("RootCircuit has no children") &&
+    !error.message.includes('"entrypoint":')
+  ) {
+    const entrypointMessage = entrypoint.startsWith("./")
+      ? entrypoint.slice(2)
+      : entrypoint
+    error.message = `${error.message}. "entrypoint": "${entrypointMessage}" is set in the runner configuration, entrypoints must contain "circuit.add(...)", you might be looking to use mainComponentPath instead if your file exports a component.`
+  }
+
+  return error
+}

--- a/tests/custom-component-with-fsmap/should-hint-main-component-path-when-entrypoint-exports-component.test.ts
+++ b/tests/custom-component-with-fsmap/should-hint-main-component-path-when-entrypoint-exports-component.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test"
+import { createCircuitWebWorker } from "lib"
+
+const expectedMessage =
+  '"entrypoint": "index.tsx" is set in the runner configuration, entrypoints must contain "circuit.add(...)", you might be looking to use mainComponentPath instead if your file exports a component.'
+
+test("should hint to use mainComponentPath when entrypoint exports a component", async () => {
+  const circuitWebWorker = await createCircuitWebWorker({
+    webWorkerUrl: new URL("../../webworker/entrypoint.ts", import.meta.url),
+  })
+
+  try {
+    await circuitWebWorker.executeWithFsMap({
+      entrypoint: "index.tsx",
+      fsMap: {
+        "index.tsx": `
+          export default () => (
+            <board width="10mm" height="10mm">
+              <resistor resistance="1k" footprint="0402" name="E1" />
+            </board>
+          )
+        `,
+      },
+    })
+
+    await expect(circuitWebWorker.renderUntilSettled()).rejects.toThrow(
+      expectedMessage,
+    )
+  } finally {
+    await circuitWebWorker.kill()
+  }
+})


### PR DESCRIPTION
## Summary
- store the configured entrypoint in the execution context and reuse it when reporting empty circuit errors
- surface a clearer hint when the entrypoint file fails to call circuit.add and the circuit is empty
- cover the new messaging with a worker regression test

## Testing
- bunx tsc --noEmit
- bun test tests/custom-component-with-fsmap/should-hint-main-component-path-when-entrypoint-exports-component.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68ed7ff811e4832e8865d4dc7564e63f