### PR TITLE
Use context tsconfig in resolver

### DIFF
--- a/lib/runner/CircuitRunner.ts
+++ b/lib/runner/CircuitRunner.ts
@@ -6,6 +6,7 @@ import type {
 import type { PlatformConfig } from "@tscircuit/props"
 import { createExecutionContext } from "../../webworker/execution-context"
 import { normalizeFsMap } from "./normalizeFsMap"
+import { getTsConfig } from "./tsconfigPaths"
 import type { RootCircuit } from "@tscircuit/core"
 import * as React from "react"
 import { importEvalPath } from "webworker/import-eval-path"
@@ -72,6 +73,7 @@ export class CircuitRunner implements CircuitRunnerApi {
 
     this._executionContext.entrypoint = opts.entrypoint!
     this._executionContext.fsMap = normalizeFsMap(opts.fsMap)
+    this._executionContext.tsConfig = getTsConfig(this._executionContext.fsMap)
     if (!this._executionContext.fsMap[opts.entrypoint!]) {
       throw new Error(`Entrypoint "${opts.entrypoint}" not found`)
     }
@@ -104,6 +106,7 @@ export class CircuitRunner implements CircuitRunnerApi {
     )
     this._bindEventListeners(this._executionContext.circuit)
     this._executionContext.fsMap["entrypoint.tsx"] = code
+    this._executionContext.tsConfig = getTsConfig(this._executionContext.fsMap)
     ;(globalThis as any).__tscircuit_circuit = this._executionContext.circuit
 
     await importEvalPath("./entrypoint.tsx", this._executionContext)
@@ -125,6 +128,7 @@ export class CircuitRunner implements CircuitRunnerApi {
     )
     this._bindEventListeners(this._executionContext.circuit)
     ;(globalThis as any).__tscircuit_circuit = this._executionContext.circuit
+    this._executionContext.tsConfig = null
 
     const element = typeof component === "function" ? component() : component
     this._executionContext.circuit.add(element as any)

--- a/lib/runner/resolveFilePath.ts
+++ b/lib/runner/resolveFilePath.ts
@@ -1,12 +1,13 @@
 import { normalizeFilePath } from "./normalizeFsMap"
 import { dirname } from "lib/utils/dirname"
-import { getTsConfig, resolveWithTsconfigPaths } from "./tsconfigPaths"
+import { resolveWithTsconfigPaths, type TsConfig } from "./tsconfigPaths"
 import { resolveRelativePath } from "lib/utils/resolveRelativePath"
 
 export const resolveFilePath = (
   unknownFilePath: string,
   fsMapOrAllFilePaths: Record<string, string> | string[],
   cwd?: string,
+  opts: { tsConfig?: TsConfig | null } = {},
 ) => {
   // Handle parent directory navigation properly
   const resolvedPath = cwd
@@ -44,11 +45,7 @@ export const resolveFilePath = (
   }
 
   // Try resolving using tsconfig "paths" mapping when the import is non-relative
-  const tsConfig =
-    !Array.isArray(fsMapOrAllFilePaths) &&
-    typeof fsMapOrAllFilePaths === "object"
-      ? getTsConfig(fsMapOrAllFilePaths)
-      : null
+  const tsConfig = opts.tsConfig ?? null
 
   if (!unknownFilePath.startsWith("./") && !unknownFilePath.startsWith("../")) {
     const viaTsconfig = resolveWithTsconfigPaths({
@@ -80,8 +77,15 @@ export const resolveFilePath = (
 export const resolveFilePathOrThrow = (
   unknownFilePath: string,
   fsMapOrAllFilePaths: Record<string, string> | string[],
+  cwd?: string,
+  opts: { tsConfig?: TsConfig | null } = {},
 ) => {
-  const resolvedFilePath = resolveFilePath(unknownFilePath, fsMapOrAllFilePaths)
+  const resolvedFilePath = resolveFilePath(
+    unknownFilePath,
+    fsMapOrAllFilePaths,
+    cwd,
+    opts,
+  )
   if (!resolvedFilePath) {
     throw new Error(
       `File not found "${unknownFilePath}", available paths:\n\n${Object.keys(fsMapOrAllFilePaths).join(", ")}`,

--- a/webworker/entrypoint.ts
+++ b/webworker/entrypoint.ts
@@ -12,6 +12,7 @@ import {
 } from "./execution-context"
 import { importEvalPath } from "./import-eval-path"
 import { normalizeFsMap } from "lib/runner/normalizeFsMap"
+import { getTsConfig } from "lib/runner/tsconfigPaths"
 import type { RootCircuit } from "@tscircuit/core"
 import { setupDefaultEntrypointIfNeeded } from "lib/runner/setupDefaultEntrypointIfNeeded"
 import { enhanceRootCircuitHasNoChildrenError } from "lib/utils/enhance-root-circuit-error"
@@ -124,6 +125,7 @@ const webWorkerApi = {
     bindEventListeners(executionContext.circuit)
     executionContext.entrypoint = entrypoint
     executionContext.fsMap = normalizeFsMap(opts.fsMap)
+    executionContext.tsConfig = getTsConfig(executionContext.fsMap)
     if (!executionContext.fsMap[entrypoint]) {
       throw new Error(`Entrypoint "${opts.entrypoint}" not found`)
     }
@@ -148,6 +150,7 @@ const webWorkerApi = {
     })
     bindEventListeners(executionContext.circuit)
     executionContext.fsMap["entrypoint.tsx"] = code
+    executionContext.tsConfig = getTsConfig(executionContext.fsMap)
     ;(globalThis as any).__tscircuit_circuit = executionContext.circuit
 
     await importEvalPath("./entrypoint.tsx", executionContext)
@@ -165,6 +168,7 @@ const webWorkerApi = {
     })
     bindEventListeners(executionContext.circuit)
     ;(globalThis as any).__tscircuit_circuit = executionContext.circuit
+    executionContext.tsConfig = null
 
     let element: any
     if (typeof component === "function") {

--- a/webworker/execution-context.ts
+++ b/webworker/execution-context.ts
@@ -5,6 +5,7 @@ import * as React from "react"
 import * as tscircuitMathUtils from "@tscircuit/math-utils"
 import type { PlatformConfig } from "@tscircuit/props"
 import { getPlatformConfig } from "lib/getPlatformConfig"
+import type { TsConfig } from "lib/runner/tsconfigPaths"
 import Debug from "debug"
 
 const debug = Debug("tsci:eval:execution-context")
@@ -21,6 +22,7 @@ export interface ExecutionContext extends WebWorkerConfiguration {
   preSuppliedImports: Record<string, any>
   circuit: RootCircuit
   logger: StoredLogger
+  tsConfig: TsConfig | null
 }
 
 export function createExecutionContext(
@@ -75,6 +77,7 @@ export function createExecutionContext(
       "@tscircuit/props": {},
     },
     circuit,
+    tsConfig: null,
     ...webWorkerConfiguration,
   }
 }

--- a/webworker/import-eval-path.ts
+++ b/webworker/import-eval-path.ts
@@ -62,6 +62,7 @@ export async function importEvalPath(
     importName,
     ctx.fsMap,
     opts.cwd,
+    { tsConfig: ctx.tsConfig },
   )
   if (resolvedLocalImportPath) {
     ctx.logger.info(`importLocalFile("${resolvedLocalImportPath}")`)
@@ -76,7 +77,10 @@ export async function importEvalPath(
 
   // Check if this matches a tsconfig path pattern but failed to resolve
   // If so, throw an error instead of falling back to npm
-  const tsConfig = getTsConfig(ctx.fsMap)
+  const tsConfig = ctx.tsConfig ?? getTsConfig(ctx.fsMap)
+  if (!ctx.tsConfig && tsConfig) {
+    ctx.tsConfig = tsConfig
+  }
   if (matchesTsconfigPathPattern(importName, tsConfig)) {
     throw new Error(
       `Import "${importName}" matches a tsconfig path alias but could not be resolved to an existing file${opts.cwd ? ` from directory "${opts.cwd}"` : ""}\n\n${ctx.logger.stringifyLogs()}`,

--- a/webworker/import-local-file.ts
+++ b/webworker/import-local-file.ts
@@ -1,7 +1,4 @@
-import {
-  resolveFilePath,
-  resolveFilePathOrThrow,
-} from "lib/runner/resolveFilePath"
+import { resolveFilePathOrThrow } from "lib/runner/resolveFilePath"
 import { dirname } from "lib/utils/dirname"
 import { getImportsFromCode } from "lib/utils/get-imports-from-code"
 import { evalCompiledJs } from "./eval-compiled-js"
@@ -24,7 +21,9 @@ export const importLocalFile = async (
 
   const { fsMap, preSuppliedImports } = ctx
 
-  const fsPath = resolveFilePathOrThrow(importName, fsMap)
+  const fsPath = resolveFilePathOrThrow(importName, fsMap, undefined, {
+    tsConfig: ctx.tsConfig,
+  })
   debug("fsPath:", fsPath)
   if (!ctx.fsMap[fsPath]) {
     debug("fsPath not found in fsMap:", fsPath)


### PR DESCRIPTION
## Summary
- rely on the execution context's tsconfig during file resolution instead of recomputing it from the filesystem map

## Testing
- bunx tsc --noEmit
- bun test tests/features/tsconfig-paths-resolution.test.tsx

------
https://chatgpt.com/codex/tasks/task_b_68f024240f28832ea74647889dd8a199