### PR TITLE
Add support for imports that use tsconfig.json baseUrl

### DIFF
--- a/lib/runner/resolveFilePath.ts
+++ b/lib/runner/resolveFilePath.ts
@@ -1,7 +1,10 @@
 import { normalizeFilePath } from "./normalizeFsMap"
-import { dirname } from "lib/utils/dirname"
-import { resolveWithTsconfigPaths, type TsConfig } from "./tsconfigPaths"
 import { resolveRelativePath } from "lib/utils/resolveRelativePath"
+import {
+  resolveWithTsconfigPaths,
+  type TsConfig,
+  resolveWithBaseUrl,
+} from "./tsconfigPaths"
 
 export const resolveFilePath = (
   unknownFilePath: string,
@@ -48,13 +51,21 @@ export const resolveFilePath = (
   const tsConfig = opts.tsConfig ?? null
 
   if (!unknownFilePath.startsWith("./") && !unknownFilePath.startsWith("../")) {
-    const viaTsconfig = resolveWithTsconfigPaths({
+    const viaPaths = resolveWithTsconfigPaths({
       importPath: unknownFilePath,
       normalizedFilePathMap,
       extensions: extension,
       tsConfig,
     })
-    if (viaTsconfig) return viaTsconfig
+    if (viaPaths) return viaPaths
+
+    const viaBaseUrl = resolveWithBaseUrl({
+      importPath: unknownFilePath,
+      normalizedFilePathMap,
+      extensions: extension,
+      tsConfig,
+    })
+    if (viaBaseUrl) return viaBaseUrl
   }
 
   // Check if it's an absolute import

--- a/lib/runner/resolveFilePath.ts
+++ b/lib/runner/resolveFilePath.ts
@@ -51,21 +51,21 @@ export const resolveFilePath = (
   const tsConfig = opts.tsConfig ?? null
 
   if (!unknownFilePath.startsWith("./") && !unknownFilePath.startsWith("../")) {
-    const viaPaths = resolveWithTsconfigPaths({
+    const resolvedPathFromPaths = resolveWithTsconfigPaths({
       importPath: unknownFilePath,
       normalizedFilePathMap,
       extensions: extension,
       tsConfig,
     })
-    if (viaPaths) return viaPaths
+    if (resolvedPathFromPaths) return resolvedPathFromPaths
 
-    const viaBaseUrl = resolveWithBaseUrl({
+    const resolvedPathFromBaseUrl = resolveWithBaseUrl({
       importPath: unknownFilePath,
       normalizedFilePathMap,
       extensions: extension,
       tsConfig,
     })
-    if (viaBaseUrl) return viaBaseUrl
+    if (resolvedPathFromBaseUrl) return resolvedPathFromBaseUrl
   }
 
   // Check if it's an absolute import

--- a/lib/runner/tsconfigPaths.ts
+++ b/lib/runner/tsconfigPaths.ts
@@ -90,7 +90,7 @@ export function resolveWithTsconfigPaths(opts: {
     }
   }
 
-  const viaBaseUrl = resolveWithBaseUrl({
+  const resolvedPathFromBaseUrl = resolveWithBaseUrl({
     importPath,
     normalizedFilePathMap,
     extensions,

--- a/lib/runner/tsconfigPaths.ts
+++ b/lib/runner/tsconfigPaths.ts
@@ -90,6 +90,46 @@ export function resolveWithTsconfigPaths(opts: {
     }
   }
 
+  const viaBaseUrl = resolveWithBaseUrl({
+    importPath,
+    normalizedFilePathMap,
+    extensions,
+    tsConfig,
+  })
+
+  if (viaBaseUrl) return viaBaseUrl
+
+  return null
+}
+
+export function resolveWithBaseUrl(opts: {
+  importPath: string
+  normalizedFilePathMap: Map<string, string>
+  extensions: string[]
+  tsConfig: TsConfig | null
+}): string | null {
+  const { importPath, normalizedFilePathMap, extensions, tsConfig } = opts
+  const baseUrl = tsConfig?.compilerOptions?.baseUrl
+  if (!baseUrl) return null
+
+  const tryResolveCandidate = (candidate: string) => {
+    const normalizedCandidate = normalizeFilePath(candidate)
+    if (normalizedFilePathMap.has(normalizedCandidate)) {
+      return normalizedFilePathMap.get(normalizedCandidate)!
+    }
+    for (const ext of extensions) {
+      const withExt = `${normalizedCandidate}.${ext}`
+      if (normalizedFilePathMap.has(withExt)) {
+        return normalizedFilePathMap.get(withExt)!
+      }
+    }
+    return null
+  }
+
+  const candidate = `${baseUrl}/${importPath}`
+  const resolved = tryResolveCandidate(candidate)
+  if (resolved) return resolved
+
   return null
 }
 

--- a/lib/runner/tsconfigPaths.ts
+++ b/lib/runner/tsconfigPaths.ts
@@ -112,23 +112,19 @@ export function resolveWithBaseUrl(opts: {
   const baseUrl = tsConfig?.compilerOptions?.baseUrl
   if (!baseUrl) return null
 
-  const tryResolveCandidate = (candidate: string) => {
-    const normalizedCandidate = normalizeFilePath(candidate)
-    if (normalizedFilePathMap.has(normalizedCandidate)) {
-      return normalizedFilePathMap.get(normalizedCandidate)!
-    }
-    for (const ext of extensions) {
-      const withExt = `${normalizedCandidate}.${ext}`
-      if (normalizedFilePathMap.has(withExt)) {
-        return normalizedFilePathMap.get(withExt)!
-      }
-    }
-    return null
+  const filePathToResolve = `${baseUrl}/${importPath}`
+  const normalizedFilePath = normalizeFilePath(filePathToResolve)
+
+  if (normalizedFilePathMap.has(normalizedFilePath)) {
+    return normalizedFilePathMap.get(normalizedFilePath)!
   }
 
-  const candidate = `${baseUrl}/${importPath}`
-  const resolved = tryResolveCandidate(candidate)
-  if (resolved) return resolved
+  for (const ext of extensions) {
+    const withExt = `${normalizedFilePath}.${ext}`
+    if (normalizedFilePathMap.has(withExt)) {
+      return normalizedFilePathMap.get(withExt)!
+    }
+  }
 
   return null
 }

--- a/lib/runner/tsconfigPaths.ts
+++ b/lib/runner/tsconfigPaths.ts
@@ -97,7 +97,7 @@ export function resolveWithTsconfigPaths(opts: {
     tsConfig,
   })
 
-  if (viaBaseUrl) return viaBaseUrl
+  if (resolvedPathFromBaseUrl) return resolvedPathFromBaseUrl
 
   return null
 }

--- a/tests/features/tsconfig-paths-resolution.test.tsx
+++ b/tests/features/tsconfig-paths-resolution.test.tsx
@@ -63,3 +63,36 @@ test("throws error when tsconfig path alias cannot be resolved (instead of tryin
     'Import "@utils/missing" matches a tsconfig path alias but could not be resolved to an existing file',
   )
 })
+
+test("resolves imports using tsconfig baseUrl", async () => {
+  const circuitJson = await runTscircuitCode(
+    {
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          baseUrl: "src",
+        },
+      }),
+      "src/utils/values.ts": `
+        export const resistorName = "RbaseUrl"
+        export const resistance = "2k"
+      `,
+      "src/component.tsx": `
+        import { resistorName, resistance } from "utils/values"
+        export default () => (<resistor name={resistorName} resistance={resistance} />)
+      `,
+      "user.tsx": `
+        import Comp from "component"
+        export default () => (<Comp />)
+      `,
+    },
+    {
+      mainComponentPath: "user",
+    },
+  )
+
+  const resistor = circuitJson.find(
+    (el) => el.type === "source_component" && el.name === "RbaseUrl",
+  ) as any
+  expect(resistor).toBeDefined()
+  expect(resistor.resistance).toBe(2000)
+})


### PR DESCRIPTION
/claim #1282 
/closes #1282 

Fixes issue #1282 by making sure don't need to specify "paths" in tsconfig in order to import files from the root directory
Created 3 test cases to verify it works

### TEST LOGS:

USER@DESKTOP-1PHUG1C MINGW64 ~/3D Objects/eval (fix-1282)
$ bun test tests/features/tsconfig-paths-resolution.test.tsx
bun test v1.2.23 (cf136713)

tests\features\tsconfig-paths-resolution.test.tsx:
✓ resolves imports using tsconfig paths aliases [1391.00ms]
✓ throws error when tsconfig path alias cannot be resolved (instead of trying jsdelivr)
✓ resolves imports using tsconfig baseUrl [609.00ms]

 3 pass
 0 fail
 5 expect() calls
Ran 3 tests across 1 file. [3.97s]