### PR TITLE
feat: Improve tsconfig.json parsing and error handling

### DIFF
--- a/lib/runner/tsconfigPaths.ts
+++ b/lib/runner/tsconfigPaths.ts
@@ -21,10 +21,15 @@ export function getTsConfig(
   const tsconfigContent = fsMapOrAllFilePaths["tsconfig.json"]
   if (!tsconfigContent) return null
   try {
-    const parsed = JSON.parse(tsconfigContent) as TsConfig
+    const sanitizedContent = tsconfigContent.replace(
+      /\/\*[\s\S]*?\*\/|\/\/.*/g,
+      "",
+    ) // remove comments
+
+    const parsed = JSON.parse(sanitizedContent) as TsConfig
     return parsed
-  } catch {
-    return null
+  } catch (e: any) {
+    throw new Error(`Failed to parse tsconfig.json: ${e.message}`)
   }
 }
 

--- a/tests/features/tsconfig-paths-resolution.test.tsx
+++ b/tests/features/tsconfig-paths-resolution.test.tsx
@@ -4,15 +4,30 @@ import { runTscircuitCode } from "lib/runner"
 test("resolves imports using tsconfig paths aliases", async () => {
   const circuitJson = await runTscircuitCode(
     {
-      "tsconfig.json": JSON.stringify({
-        compilerOptions: {
-          baseUrl: ".",
-          paths: {
+      "tsconfig.json": `{
+        "compilerOptions": {
+          "target": "ES6",
+          // "target": "ES6",
+          "module": "ESNext",
+          "jsx": "react-jsx",
+          "outDir": "dist",
+          "strict": true,
+          "esModuleInterop": true,
+          "moduleResolution": "node",
+          "skipLibCheck": true,
+          "forceConsistentCasingInFileNames": true,
+          "resolveJsonModule": true,
+          "sourceMap": true,
+          "allowSyntheticDefaultImports": true,
+          "experimentalDecorators": true,
+          "types": ["tscircuit", "bun"],
+          "baseUrl": ".",
+          "paths": {
             "@src/*": ["./src/*"],
-            "@utils/*": ["./src/utils/*"],
-          },
-        },
-      }),
+            "@utils/*": ["./src/utils/*"]
+          }
+        }
+      }`,
       "src/utils/values.ts": `
         export const resistorName = "Rpaths"
         export const resistance = "1k"
@@ -95,4 +110,18 @@ test("resolves imports using tsconfig baseUrl", async () => {
   ) as any
   expect(resistor).toBeDefined()
   expect(resistor.resistance).toBe(2000)
+})
+
+test("throws error when tsconfig.json is malformed", async () => {
+  await expect(
+    runTscircuitCode(
+      {
+        "tsconfig.json": `{ "compilerOptions": { baseUrl": "src" } }`, // Malformed JSON
+        "user.tsx": `export default () => (<resistor name="R1" resistance="1k" />)`,
+      },
+      {
+        mainComponentPath: "user",
+      },
+    ),
+  ).rejects.toThrow(/Failed to parse tsconfig.json/)
 })


### PR DESCRIPTION
This pull request improves the handling of tsconfig.json files to make     
parsing more robust and provide clearer error messages.                    

 • Updated getTsConfig to strip comments from tsconfig.json content before 
   parsing, as comments are common in these files but not supported by     
   standard JSON.parse.                                                    
 • Modified getTsConfig to throw a descriptive error when JSON parsing     
   fails, making it easier to diagnose malformed configuration files.      
 • Added a new test case to verify that an invalid tsconfig.json correctly 
   throws an error. 

/claim #1317
/closes #1317