### PR TITLE
Fix circular dependency detection for export star-as re-exports

### DIFF
--- a/lib/utils/get-imports-from-code.ts
+++ b/lib/utils/get-imports-from-code.ts
@@ -12,7 +12,7 @@ export const getImportsFromCode = (code: string): string[] => {
 
   // Match re-exports
   const reExportRegex =
-    /^\s*export\s+(?:\*|(?:\{[\s\w,]+\}))\s+from\s*['"](.+?)['"]/gm
+    /^\s*export\s+(?:type\s+)?(?:\*\s+as\s+[\w$]+|\*|\{[^}]+\})\s+from\s*['"](.+?)['"]/gm
   let reExportMatch: RegExpExecArray | null
   // biome-ignore lint/suspicious/noAssignInExpressions: <explanation>
   while ((reExportMatch = reExportRegex.exec(code)) !== null) {

--- a/tests/features/circular-dependency-detection-export-star-as.test.tsx
+++ b/tests/features/circular-dependency-detection-export-star-as.test.tsx
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test"
+import { createCircuitWebWorker } from "lib"
+
+const workerUrl = new URL("../../webworker/entrypoint.ts", import.meta.url)
+
+test("detects circular dependencies through export star as re-exports", async () => {
+  const worker = await createCircuitWebWorker({
+    webWorkerUrl: workerUrl,
+  })
+
+  const execution = worker.executeWithFsMap({
+    fsMap: {
+      "entrypoint.tsx": `
+        import { ComponentA } from "./ComponentA"
+
+        circuit.add(<ComponentA />)
+      `,
+      "ComponentA.tsx": `
+        export * as ComponentBModule from "./ComponentB"
+
+        export const ComponentA = () => null
+      `,
+      "ComponentB.tsx": `
+        import { ComponentBModule } from "./ComponentA"
+
+        export const ComponentB = () => ComponentBModule.ComponentA
+      `,
+    },
+    entrypoint: "entrypoint.tsx",
+  })
+
+  let capturedError: unknown
+  try {
+    await execution
+  } catch (error) {
+    capturedError = error
+  } finally {
+    await worker.kill()
+  }
+
+  expect(capturedError).toBeDefined()
+  expect(capturedError).toBeInstanceOf(Error)
+  const errorMessage = (capturedError as Error).message
+  expect(errorMessage).toContain(
+    'Circular dependency detected while importing "ComponentA.tsx"',
+  )
+  expect(errorMessage).toContain(
+    "ComponentA.tsx -> ComponentB.tsx -> ComponentA.tsx",
+  )
+})


### PR DESCRIPTION
## Summary
- update the import scanner to recognize `export * as … from` re-exports so they participate in cycle detection
- add a regression test covering circular dependencies created through export namespace re-exports

## Testing
- bun test tests/features/circular-dependency-detection-export-star-as.test.tsx
- bun test tests/features/circular-dependency-detection.test.tsx
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68f7f6f84d24832e9fbbd83c32f827aa