### PR TITLE
Ignore type-only imports when resolving dependencies

### DIFF
--- a/lib/utils/get-imports-from-code.ts
+++ b/lib/utils/get-imports-from-code.ts
@@ -7,6 +7,10 @@ export const getImportsFromCode = (code: string): string[] => {
 
   // biome-ignore lint/suspicious/noAssignInExpressions: <explanation>
   while ((match = importRegex.exec(code)) !== null) {
+    const fullMatch = match[0]
+    if (/^\s*import\s+type\b/.test(fullMatch)) {
+      continue
+    }
     imports.push(match[1])
   }
 
@@ -16,6 +20,10 @@ export const getImportsFromCode = (code: string): string[] => {
   let reExportMatch: RegExpExecArray | null
   // biome-ignore lint/suspicious/noAssignInExpressions: <explanation>
   while ((reExportMatch = reExportRegex.exec(code)) !== null) {
+    const fullMatch = reExportMatch[0]
+    if (/^\s*export\s+type\b/.test(fullMatch)) {
+      continue
+    }
     imports.push(reExportMatch[1])
   }
 

--- a/tests/features/import-type-does-not-cause-circular.test.tsx
+++ b/tests/features/import-type-does-not-cause-circular.test.tsx
@@ -1,0 +1,42 @@
+import { expect, test } from "bun:test"
+import { createCircuitWebWorker } from "lib"
+
+const workerUrl = new URL("../../webworker/entrypoint.ts", import.meta.url)
+
+test("import type does not trigger circular dependency detection", async () => {
+  const worker = await createCircuitWebWorker({
+    webWorkerUrl: workerUrl,
+  })
+
+  const execution = worker.executeWithFsMap({
+    fsMap: {
+      "entrypoint.tsx": `
+        import { ComponentA } from "./ComponentA"
+
+        circuit.add(<ComponentA message="hello" />)
+      `,
+      "ComponentA.tsx": `
+        import { ComponentB } from "./ComponentB"
+
+        export type ComponentAProps = { message: string }
+
+        export const ComponentA = ({ message }: ComponentAProps) => (
+          <ComponentB message={message} />
+        )
+      `,
+      "ComponentB.tsx": `
+        import type { ComponentAProps } from "./ComponentA"
+
+        export const ComponentB = ({ message }: ComponentAProps) => {
+          void message
+          return null
+        }
+      `,
+    },
+    entrypoint: "entrypoint.tsx",
+  })
+
+  await expect(execution).resolves.toBeUndefined()
+
+  await worker.kill()
+})


### PR DESCRIPTION
## Summary
- skip `import type` statements when collecting dependency names
- add a regression test to ensure type-only imports do not trigger circular detection

## Testing
- bun test tests/features/import-type-does-not-cause-circular.test.tsx
- bunx tsc --noEmit


------
https://chatgpt.com/codex/tasks/task_b_68f7fa6cb194832e94af7cc15f816ee3