### PR TITLE
feat: Dynamically load ngspice engine with CDN fallback

### DIFF
--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -81,8 +81,11 @@ jobs:
             echo "Running tests in $test_file"
             attempt=1
             while [ $attempt -le 4 ]; do
-              bun test "$test_file" --timeout 30000
-              code=$?
+              if bun test "$test_file" --timeout 30000; then
+                code=0
+              else
+                code=$?
+              fi
 
               if [ $code -eq 0 ]; then
                 break

--- a/browser-tests/browsertest.ts
+++ b/browser-tests/browsertest.ts
@@ -108,9 +108,9 @@ async function runNgspiceTest() {
 // Run the test when the page loads
 window.addEventListener("DOMContentLoaded", () => {
   const urlParams = new URLSearchParams(window.location.search)
-  const testToRun = urlParams.get("test")
+  const test_to_run = urlParams.get("test_to_run")
 
-  if (testToRun === "ngspice") {
+  if (test_to_run === "ngspice") {
     runNgspiceTest()
   } else {
     runDefaultTest()

--- a/lib/utils/dynamically-load-dependency-with-cdn-backup.ts
+++ b/lib/utils/dynamically-load-dependency-with-cdn-backup.ts
@@ -1,0 +1,34 @@
+export const dynamicallyLoadDependencyWithCdnBackup = async (
+  packageName: string,
+): Promise<any> => {
+  try {
+    // First, try to import using Node.js resolution
+    const module = await import(packageName)
+    return module.default
+  } catch (e) {
+    console.log(`Failed to load ${packageName} locally, trying CDN fallback...`)
+    // Fallback to JsDelivr CDN for browser environments
+    try {
+      const res = await fetch(
+        `https://cdn.jsdelivr.net/npm/${packageName}/+esm`,
+      )
+      if (!res.ok) {
+        throw new Error(
+          `Failed to fetch ${packageName} from CDN: ${res.statusText}`,
+        )
+      }
+      const code = await res.text()
+      const blob = new Blob([code], { type: "application/javascript" })
+      const url = URL.createObjectURL(blob)
+      try {
+        const { default: loadedModule } = await import(url)
+        return loadedModule
+      } finally {
+        URL.revokeObjectURL(url)
+      }
+    } catch (cdnError) {
+      console.error(`CDN fallback for ${packageName} also failed:`, cdnError)
+      throw cdnError
+    }
+  }
+}

--- a/tests/features/ngspice-simulation.test.tsx
+++ b/tests/features/ngspice-simulation.test.tsx
@@ -1,16 +1,10 @@
 import { test, expect } from "bun:test"
 import { createCircuitWebWorker } from "lib"
-import createNgspiceSpiceEngine from "@tscircuit/ngspice-spice-engine"
 
 test(
   "spice-analysis with the ngspice engine for a switch circuit",
   async () => {
     const circuitWebWorker = await createCircuitWebWorker({
-      platform: {
-        spiceEngineMap: {
-          ngspice: await createNgspiceSpiceEngine(),
-        },
-      },
       webWorkerUrl: new URL("../../webworker/entrypoint.ts", import.meta.url),
     })
 
@@ -54,7 +48,7 @@ test(
 )
 
 test(
-  "Choosing ngspice when it's not in the platform config",
+  "Choosing an unknown spice engine throws an error",
   async () => {
     const circuitWebWorker = await createCircuitWebWorker({
       webWorkerUrl: new URL("../../webworker/entrypoint.ts", import.meta.url),
@@ -77,14 +71,14 @@ test(
             <analogsimulation
               duration="4ms"
               timePerStep="10us"
-              spiceEngine="ngspice"
+              spiceEngine="not-a-real-engine"
             />
           </board>
         )
       `)
 
-      expect(circuitWebWorker.renderUntilSettled()).rejects.toThrow(
-        'SPICE engine "ngspice" not found in platform config. Available engines: []',
+      await expect(circuitWebWorker.renderUntilSettled()).rejects.toThrow(
+        'SPICE engine "not-a-real-engine" not found in platform config. Available engines: ["ngspice"]',
       )
     } finally {
       await circuitWebWorker.kill()

--- a/tests/features/ngspice-simulation.test.tsx
+++ b/tests/features/ngspice-simulation.test.tsx
@@ -1,0 +1,94 @@
+import { test, expect } from "bun:test"
+import { createCircuitWebWorker } from "lib"
+import createNgspiceSpiceEngine from "@tscircuit/ngspice-spice-engine"
+
+test(
+  "spice-analysis with the ngspice engine for a switch circuit",
+  async () => {
+    const circuitWebWorker = await createCircuitWebWorker({
+      platform: {
+        spiceEngineMap: {
+          ngspice: await createNgspiceSpiceEngine(),
+        },
+      },
+      webWorkerUrl: new URL("../../webworker/entrypoint.ts", import.meta.url),
+    })
+
+    try {
+      await circuitWebWorker.execute(`
+    circuit.add(
+      <board schMaxTraceDistance={10} routingDisabled>
+        <voltagesource name="V1" voltage="5V" />
+        <switch name="SW1" spst simSwitchFrequency="1kHz" />
+        <trace from=".V1 > .terminal1" to=".SW1 > .pin1" />
+        <resistor
+          name="R1"
+          resistance="1k"
+          footprint="0402"
+          connections={{ pin1: ".SW1 > .pin2", pin2: ".V1 > .terminal2" }}
+        />
+        <voltageprobe connectsTo={".R1 > .pin1"} />
+        <analogsimulation
+          duration="4ms"
+          timePerStep="10us"
+          spiceEngine="ngspice"
+        />
+      </board>
+    )
+  `)
+
+      await circuitWebWorker.renderUntilSettled()
+
+      const circuitJson = await circuitWebWorker.getCircuitJson()
+
+      expect(
+        circuitJson.some(
+          (el) => el.type === "simulation_transient_voltage_graph",
+        ),
+      ).toBe(true)
+    } finally {
+      await circuitWebWorker.kill()
+    }
+  },
+  { timeout: 20000 },
+)
+
+test(
+  "Choosing ngspice when it's not in the platform config",
+  async () => {
+    const circuitWebWorker = await createCircuitWebWorker({
+      webWorkerUrl: new URL("../../webworker/entrypoint.ts", import.meta.url),
+    })
+
+    try {
+      await circuitWebWorker.execute(`
+        circuit.add(
+          <board schMaxTraceDistance={10} routingDisabled>
+            <voltagesource name="V1" voltage="5V" />
+            <switch name="SW1" spst simSwitchFrequency="1kHz" />
+            <trace from=".V1 > .terminal1" to=".SW1 > .pin1" />
+            <resistor
+              name="R1"
+              resistance="1k"
+              footprint="0402"
+              connections={{ pin1: ".SW1 > .pin2", pin2: ".V1 > .terminal2" }}
+            />
+            <voltageprobe connectsTo={".R1 > .pin1"} />
+            <analogsimulation
+              duration="4ms"
+              timePerStep="10us"
+              spiceEngine="ngspice"
+            />
+          </board>
+        )
+      `)
+
+      expect(circuitWebWorker.renderUntilSettled()).rejects.toThrow(
+        'SPICE engine "ngspice" not found in platform config. Available engines: []',
+      )
+    } finally {
+      await circuitWebWorker.kill()
+    }
+  },
+  { timeout: 20000 },
+)


### PR DESCRIPTION
This introduces dynamic, on-demand loading for the ngspice engine and configures it as the default SPICE simulation engine.             

The loading mechanism first attempts a local dynamic import(). If this fails (e.g., in a browser), it falls back to fetching the engine from the jsDelivr CDN. This ensures ngspice is available in both Node.js and browser environments without impacting initial load times. 

A Playwright test has been added to verify the CDN fallback functionality in a browser.