### PR TITLE
Use Playwright `baseURL` for cleaner test navigation

### DIFF
--- a/browser-tests/browser.test.ts
+++ b/browser-tests/browser.test.ts
@@ -6,7 +6,7 @@ test("browser test server shows Success", async ({ page }) => {
   await new Promise((resolve) => setTimeout(resolve, 1000))
 
   // Navigate to the page
-  await page.goto("http://localhost:3070")
+  await page.goto("/")
 
   // Wait for the success message or timeout
   await expect(page.locator("#output")).toContainText("Success", {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,12 +12,13 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: "html",
   use: {
+    baseURL: "http://localhost:3070",
     actionTimeout: 0,
     trace: "on-first-retry",
   },
   webServer: {
     command: "bun run start:browser-test-server",
-    port: 3070,
+    url: "http://localhost:3070",
     reuseExistingServer: !process.env.CI,
   },
 })


### PR DESCRIPTION
**Description:**

* Added `baseURL: "http://localhost:3070"` in `playwright.config.ts`
* Updated test to use relative path `page.goto("/")`
* Replaced `port` with `url` in `webServer` config
* Simplifies navigation and improves config consistency

<img width="1212" height="442" alt="image" src="https://github.com/user-attachments/assets/61bfa0d6-2904-4063-992a-a1bed2cb66ec" />

