### PR TITLE
Integrate release tracker notifications

### DIFF
--- a/.github/workflows/bun-pver-release.yml
+++ b/.github/workflows/bun-pver-release.yml
@@ -70,3 +70,19 @@ jobs:
                 -d "{\"ref\":\"main\",\"inputs\":{\"package_names\":\"${{ env.UPSTREAM_PACKAGES_TO_UPDATE }}\"}}"
             fi
           done
+      - name: Notify release-tracker of version update
+        # Continue-on-error just in case the tracker is down
+        continue-on-error: true
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          PACKAGE_JSON=$(cat package.json)
+          curl -X POST https://release-tracker.tscircuit.com/release_events/create \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"event\": {
+                \"event_type\": \"versions_updated\",
+                \"repo\": \"tscircuit/eval\",
+                \"version\": \"$VERSION\",
+                \"package_json\": $PACKAGE_JSON
+              }
+            }"

--- a/.github/workflows/on-merge-inform-release-tracker.yml
+++ b/.github/workflows/on-merge-inform-release-tracker.yml
@@ -1,0 +1,24 @@
+name: Release Tracker - Feature Merge
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  track-feature-merge:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send feature merge event
+        continue-on-error: true
+        run: |
+          FEATURE_NAME=$(echo "${{ github.event.pull_request.user.login }}: ${{ github.event.pull_request.title }} #${{ github.event.pull_request.number }}" | jq -R .)
+          curl -X POST https://release-tracker.tscircuit.com/release_events/create \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"event\": {
+                \"event_type\": \"feature_merged\",
+                \"repo\": \"tscircuit/eval\",
+                \"feature_name\": $FEATURE_NAME
+              }
+            }"


### PR DESCRIPTION
## Summary
- add release tracker notification step to the publish workflow
- report merged pull requests to the release tracker service

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_69096268e928832eac55171c8cf228c5