### PR TITLE
feat: Implement partsEngineDisabled functionality

### DIFF
--- a/tests/features/parts-engine-disabled.test.tsx
+++ b/tests/features/parts-engine-disabled.test.tsx
@@ -1,0 +1,62 @@
+import { CircuitRunner } from "lib/runner/CircuitRunner"
+import { expect, test } from "bun:test"
+import type { SourceComponentBase } from "circuit-json"
+import { getPlatformConfig } from "lib/getPlatformConfig"
+
+test("partsEngine can be disabled via projectConfig", async () => {
+  const runner = new CircuitRunner({
+    projectConfig: {
+      partsEngineDisabled: true,
+    },
+  })
+
+  await runner.execute(`
+    circuit.add(
+      <board>
+        <resistor name="R1" resistance="1k" footprint="0402" />
+      </board>
+    )
+  `)
+
+  await runner.renderUntilSettled()
+
+  const circuitJson = await runner.getCircuitJson()
+
+  const source_component = circuitJson.find(
+    (el) => el.type === "source_component",
+  ) as SourceComponentBase
+  expect(source_component).toBeDefined()
+  expect(source_component.supplier_part_numbers).toBeUndefined()
+
+  await runner.kill()
+})
+
+test("partsEngine can be disabled via platform config", async () => {
+  const runner = new CircuitRunner({
+    platform: {
+      ...getPlatformConfig(),
+      partsEngineDisabled: true,
+    },
+  })
+
+  await runner.execute(`
+    circuit.add(
+      <board>
+        <resistor name="R1" resistance="1k" footprint="0402" />
+      </board>
+    )
+  `)
+
+  await runner.renderUntilSettled()
+
+  const circuitJson = await runner.getCircuitJson()
+
+  const source_component = circuitJson.find(
+    (el) => el.type === "source_component",
+  ) as SourceComponentBase
+
+  expect(source_component).toBeDefined()
+  expect(source_component.supplier_part_numbers).toBeUndefined()
+
+  await runner.kill()
+})

--- a/webworker/execution-context.ts
+++ b/webworker/execution-context.ts
@@ -43,6 +43,10 @@ export function createExecutionContext(
     ? { ...basePlatform, ...opts.projectConfig }
     : basePlatform
 
+  if (platform.partsEngineDisabled) {
+    platform.partsEngine = undefined
+  }
+
   const circuit = new RootCircuit({
     platform,
   })


### PR DESCRIPTION
This makes the partsEngineDisabled property functional. When partsEngineDisabled is set to true in the     
configuration (platform or projectConfig), the partsEngine is explicitly set to undefined.                        

A new test file with two test cases has been added to verify that the parts engine is disabled when the flag is   
set via either projectConfig or the main platform config. 