### PR TITLE
Add the global polyfill

### DIFF
--- a/webworker/entrypoint.ts
+++ b/webworker/entrypoint.ts
@@ -22,6 +22,10 @@ import { setValueAtPath } from "lib/shared/obj-path"
 globalThis.React = React
 setupFetchProxy()
 
+// Polyfill for Node.js global object in browser workers
+// Needed because @tscircuit/core and dependencies reference global.debugGraphics/debugOutputArray
+globalThis.global = globalThis.global || globalThis
+
 let executionContext: ExecutionContext | null = null
 let debugNamespace: string | undefined
 
@@ -196,7 +200,7 @@ const webWorkerApi = {
     let element: any
     if (typeof component === "function") {
       element = component()
-    } else if (component && component.__isSerializedReactElement) {
+    } else if (component?.__isSerializedReactElement) {
       element = deserializeReactElement(component)
     } else {
       element = component


### PR DESCRIPTION
Cause core is using `global?.graphicsDebug` and that is breaking the debug render logs

<img width="1972" height="1434" alt="image" src="https://github.com/user-attachments/assets/37c75cbe-d2ac-486d-ae3a-ab99dc5fabcc" />
