### PR TITLE
Handle export type star reexports

### DIFF
--- a/tests/features/export-type-star-reexports.test.tsx
+++ b/tests/features/export-type-star-reexports.test.tsx
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test"
+import { createCircuitWebWorker } from "lib"
+
+const workerUrl = new URL("../../webworker/entrypoint.ts", import.meta.url)
+
+test("export type * re-exports do not break evaluation", async () => {
+  const worker = await createCircuitWebWorker({
+    webWorkerUrl: workerUrl,
+  })
+
+  const execution = worker.executeWithFsMap({
+    fsMap: {
+      "entrypoint.tsx": `
+        import { ComponentA } from "./ComponentA"
+
+        circuit.add(<ComponentA message="hello" />)
+      `,
+      "ComponentA.tsx": `
+        import type { ComponentProps } from "./component-types"
+
+        export type * from "./component-types"
+
+        export const ComponentA = ({ message }: ComponentProps) => {
+          void message
+          return null
+        }
+      `,
+      "component-types.ts": `
+        export type ComponentProps = { message: string }
+      `,
+    },
+    entrypoint: "entrypoint.tsx",
+  })
+
+  await expect(execution).resolves.toBeUndefined()
+
+  await worker.kill()
+})

--- a/webworker/transform-with-sucrase.ts
+++ b/webworker/transform-with-sucrase.ts
@@ -2,6 +2,11 @@ import { transform, type Transform as SucraseTransform } from "sucrase"
 
 const TS_EXTENSIONS = new Set([".ts", ".tsx", ".mts", ".cts"])
 const JSX_EXTENSIONS = new Set([".tsx", ".jsx", ".ts"])
+const TYPE_STAR_EXPORT_REGEX =
+  /^\s*export\s+type\s+\*\s+(?:as\s+[\w$]+\s+)?from\s+['"][^'"]+['"]\s*;?\s*$/gim
+
+const stripTypeStarExports = (code: string) =>
+  code.replace(TYPE_STAR_EXPORT_REGEX, "")
 
 const stripQueryAndHash = (filePath: string) => {
   const queryIndex = filePath.indexOf("?")
@@ -58,7 +63,8 @@ const getTransformsForFilePath = (filePath: string) => {
 
 export const transformWithSucrase = (code: string, filePath: string) => {
   const transforms = getTransformsForFilePath(filePath)
-  const { code: transformedCode } = transform(code, {
+  const sanitizedCode = stripTypeStarExports(code)
+  const { code: transformedCode } = transform(sanitizedCode, {
     filePath,
     production: true,
     transforms,


### PR DESCRIPTION
## Summary
- strip type-only `export type * from` statements before invoking Sucrase so that new TS syntax no longer triggers SyntaxErrors during evaluation
- add a regression test to ensure components that re-export types with `export type *` execute successfully in the worker

## Testing
- bun test tests/features/export-type-star-reexports.test.tsx
- bunx tsc --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691bc7a3ef60832ea926dd810492ee7a)