### PR TITLE
fix: non-relative path resolution when baseUrl is present

### DIFF
--- a/lib/runner/tsconfigPaths.ts
+++ b/lib/runner/tsconfigPaths.ts
@@ -134,10 +134,10 @@ export function resolveWithBaseUrl(opts: {
 
   // Resolve baseUrl relative to tsconfig location
   const baseDir = tsconfigDir || "."
-  const filePathToResolve = `${baseDir}/${baseUrl}/${importPath}`.replace(
-    /\/\//g,
-    "/",
-  )
+  let filePathToResolve = `${baseDir}/${baseUrl}/${importPath}`
+  // Clean up multiple slashes and leading dots
+  filePathToResolve = filePathToResolve.replace(/\/+/g, "/") // Replace multiple slashes with single slash
+  filePathToResolve = filePathToResolve.replace(/\/\.\//g, "/") // Replace /./ with /
   const normalizedFilePath = normalizeFilePath(filePathToResolve)
 
   if (normalizedFilePathMap.has(normalizedFilePath)) {

--- a/tests/custom-component-with-fsmap/should-resolve-imports-with-src-baseurl-from-tsconfig.test.ts
+++ b/tests/custom-component-with-fsmap/should-resolve-imports-with-src-baseurl-from-tsconfig.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test"
+import { createCircuitWebWorker } from "lib"
+
+test("should resolve imports using baseUrl set to src directory from tsconfig.json", async () => {
+  // Note: baseUrl should be specified without leading "./" (e.g., "src" not "./src")
+  const circuitWebWorker = createCircuitWebWorker({
+    webWorkerUrl: new URL("../../webworker/entrypoint.ts", import.meta.url),
+  })
+
+  const worker = await circuitWebWorker
+  await worker.executeWithFsMap({
+    fsMap: {
+      "tsconfig.json": `{
+  "compilerOptions": {
+    "baseUrl": "src"
+  }
+}`,
+      "index.tsx": `
+import MyLed from "components/MyLed"
+import MyResistor from "components/MyResistor"
+
+export default () => (
+  <board width="20mm" height="20mm">
+    <MyLed />
+    <MyResistor />
+  </board>
+)
+      `,
+      "src/components/MyLed.tsx": `
+export default () => (
+  <led name="LED1" footprint="0805" />
+)
+      `,
+      "src/components/MyResistor.tsx": `
+export default () => (
+  <resistor resistance="10k" footprint="0402" name="R1" />
+)
+      `,
+    },
+    mainComponentPath: "index.tsx",
+  })
+
+  await worker.renderUntilSettled()
+
+  const circuitJson = await worker.getCircuitJson()
+  expect(circuitJson.filter((el: any) => el.name === "LED1")).toHaveLength(1)
+  expect(circuitJson.filter((el: any) => el.name === "R1")).toHaveLength(1)
+
+  await worker.kill()
+})

--- a/tests/custom-component-with-fsmap/should-resolve-nested-imports-with-baseurl.test.ts
+++ b/tests/custom-component-with-fsmap/should-resolve-nested-imports-with-baseurl.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "bun:test"
+import { createCircuitWebWorker } from "lib"
+
+test("should resolve nested component imports using baseUrl from tsconfig.json", async () => {
+  const circuitWebWorker = createCircuitWebWorker({
+    webWorkerUrl: new URL("../../webworker/entrypoint.ts", import.meta.url),
+  })
+
+  const worker = await circuitWebWorker
+  await worker.executeWithFsMap({
+    fsMap: {
+      "tsconfig.json": `{
+  "compilerOptions": {
+    "baseUrl": "."
+  }
+}`,
+      "index.tsx": `
+import PowerSupply from "circuits/PowerSupply"
+
+export default () => (
+  <board width="30mm" height="30mm">
+    <PowerSupply />
+  </board>
+)
+      `,
+      "circuits/PowerSupply.tsx": `
+import Resistor from "components/Resistor"
+import Capacitor from "components/Capacitor"
+
+export default () => (
+  <group>
+    <Resistor />
+    <Capacitor />
+  </group>
+)
+      `,
+      "components/Resistor.tsx": `
+export default () => (
+  <resistor resistance="10k" footprint="0402" name="R1" />
+)
+      `,
+      "components/Capacitor.tsx": `
+export default () => (
+  <capacitor capacitance="10uF" footprint="0805" name="C1" />
+)
+      `,
+    },
+    mainComponentPath: "index.tsx",
+  })
+
+  await worker.renderUntilSettled()
+
+  const circuitJson = await worker.getCircuitJson()
+  expect(circuitJson.filter((el: any) => el.name === "R1")).toHaveLength(1)
+  expect(circuitJson.filter((el: any) => el.name === "C1")).toHaveLength(1)
+
+  await worker.kill()
+})


### PR DESCRIPTION
When the baseUrl was present with non-relative file import, it had a fallback to use the absolute import. So, even when you have incorrect baseUrl configured the tests were passing.

<img width="1288" height="746" alt="image" src="https://github.com/user-attachments/assets/682b9d12-4f30-4a17-ae3c-e9ca0fe30b3b" />


@seveibar 