### PR TITLE
feat: support the resolveFilePath for static assets as their path is string assigned to variable which got skipped on resolution

### DIFF
--- a/lib/utils/get-imports-from-code.ts
+++ b/lib/utils/get-imports-from-code.ts
@@ -1,28 +1,28 @@
 export const getImportsFromCode = (code: string): string[] => {
   const importsSet = new Set<string>()
 
-  // Match ES6 import statements
+  // Match ES6 import statements (allow semicolon before import to handle minified code)
   const importRegex =
-    /^\s*import\s+(?:(?:[\w\s]+,\s*)?(?:\*\s+as\s+[\w\s]+|\{[\s\w,]+\}|\w+)\s+from\s*)?['"](.+?)['"]/gm
+    /(?:^|;)\s*import\s+(?:(?:[\w\s]+,\s*)?(?:\*\s+as\s+[\w\s]+|\{[\s\w,]+\}|\w+)\s+from\s*)?['"](.+?)['"]/gm
   let match: RegExpExecArray | null
 
   // biome-ignore lint/suspicious/noAssignInExpressions: <explanation>
   while ((match = importRegex.exec(code)) !== null) {
     const fullMatch = match[0]
-    if (/^\s*import\s+type\b/.test(fullMatch)) {
+    if (/import\s+type\b/.test(fullMatch)) {
       continue
     }
     importsSet.add(match[1])
   }
 
-  // Match re-exports
+  // Match re-exports (allow semicolon before export to handle minified code)
   const reExportRegex =
-    /^\s*export\s+(?:type\s+)?(?:\*\s+as\s+[\w$]+|\*|\{[^}]+\})\s+from\s*['"](.+?)['"]/gm
+    /(?:^|;)\s*export\s+(?:type\s+)?(?:\*\s+as\s+[\w$]+|\*|\{[^}]+\})\s+from\s*['"](.+?)['"]/gm
   let reExportMatch: RegExpExecArray | null
   // biome-ignore lint/suspicious/noAssignInExpressions: <explanation>
   while ((reExportMatch = reExportRegex.exec(code)) !== null) {
     const fullMatch = reExportMatch[0]
-    if (/^\s*export\s+type\b/.test(fullMatch)) {
+    if (/export\s+type\b/.test(fullMatch)) {
       continue
     }
     importsSet.add(reExportMatch[1])

--- a/lib/utils/get-static-asset-paths-from-code.ts
+++ b/lib/utils/get-static-asset-paths-from-code.ts
@@ -1,0 +1,44 @@
+import { STATIC_ASSET_EXTENSIONS } from "./static-assets-extension"
+
+/**
+ * Extracts static asset paths from transpiled code that uses string variable assignments.
+ *
+ * This handles cases where build tools convert:
+ *   import glbUrl from "./assets/file.glb"
+ * Into:
+ *   var glbUrl = "./assets/file.glb"
+ *
+ * @param code - The source code to scan
+ * @returns Array of relative paths to static assets
+ */
+export const getStaticAssetPathsFromCode = (code: string): string[] => {
+  const pathsSet = new Set<string>()
+
+  // Match variable assignments with quoted strings ending in static asset extensions
+  // Handles: var x = "...", const x = "...", let x = "..."
+  const extensionsPattern = STATIC_ASSET_EXTENSIONS.join("|")
+  const varAssignmentRegex = new RegExp(
+    `(?:var|const|let)\\s+\\w+\\s*=\\s*["'](\\.?\\.?\\/[^"']+\\.(${extensionsPattern}))["']`,
+    "g",
+  )
+
+  let match: RegExpExecArray | null = varAssignmentRegex.exec(code)
+  while (match !== null) {
+    pathsSet.add(match[1])
+    match = varAssignmentRegex.exec(code)
+  }
+
+  // Also match object property assignments: glbPath: "./assets/file.glb"
+  const propAssignmentRegex = new RegExp(
+    `\\w+\\s*:\\s*["'](\\.?\\.?\\/[^"']+\\.(${extensionsPattern}))["']`,
+    "g",
+  )
+
+  let match2: RegExpExecArray | null = propAssignmentRegex.exec(code)
+  while (match2 !== null) {
+    pathsSet.add(match2[1])
+    match2 = propAssignmentRegex.exec(code)
+  }
+
+  return Array.from(pathsSet)
+}

--- a/lib/utils/static-assets-extension.ts
+++ b/lib/utils/static-assets-extension.ts
@@ -1,0 +1,14 @@
+export const STATIC_ASSET_EXTENSIONS = [
+  "glb",
+  "gltf",
+  "obj",
+  "stl",
+  "step",
+  "kicad_mod",
+  "kicad_pcb",
+  "png",
+  "jpg",
+  "jpeg",
+  "svg",
+  "gif",
+]

--- a/lib/utils/transform-static-asset-paths.ts
+++ b/lib/utils/transform-static-asset-paths.ts
@@ -1,0 +1,69 @@
+import { resolveFilePath } from "lib/runner/resolveFilePath"
+import { STATIC_ASSET_EXTENSIONS } from "./static-assets-extension"
+
+/**
+ * Transforms static asset path variables in transpiled code to use resolved imports.
+ *
+ * Converts:
+ *   var glbUrl = "./assets/file.glb"
+ * To:
+ *   var glbUrl = require("./assets/file.glb").default
+ *
+ * This allows the runtime to use the resolved URL instead of the raw string.
+ *
+ * @param code - The source code to transform
+ * @param fsMap - The file system map for path resolution
+ * @param cwd - Current working directory for relative path resolution
+ * @returns Transformed code with static asset paths converted to require calls
+ */
+export const transformStaticAssetPaths = (
+  code: string,
+  fsMap: Record<string, string> | string[],
+  cwd?: string,
+): string => {
+  const extensionsPattern = STATIC_ASSET_EXTENSIONS.join("|")
+
+  // Match variable assignments with static asset paths
+  const varAssignmentRegex = new RegExp(
+    `((?:var|const|let)\\s+\\w+\\s*=\\s*)["'](\\.?\\.?\\/[^"']+\\.(${extensionsPattern}))["']`,
+    "g",
+  )
+
+  let transformedCode = code.replace(
+    varAssignmentRegex,
+    (match, prefix, assetPath) => {
+      // Check if this path can be resolved
+      const resolvedPath = resolveFilePath(assetPath, fsMap, cwd)
+
+      if (resolvedPath) {
+        // Replace the string literal with a require call
+        // This will use the resolved URL from preSuppliedImports
+        return `${prefix}require("${assetPath}").default`
+      }
+
+      // If not resolved, leave as-is
+      return match
+    },
+  )
+
+  // Also transform object property assignments
+  const propAssignmentRegex = new RegExp(
+    `(\\w+\\s*:\\s*)["'](\\.?\\.?\\/[^"']+\\.(${extensionsPattern}))["']`,
+    "g",
+  )
+
+  transformedCode = transformedCode.replace(
+    propAssignmentRegex,
+    (match, prefix, assetPath) => {
+      const resolvedPath = resolveFilePath(assetPath, fsMap, cwd)
+
+      if (resolvedPath) {
+        return `${prefix}require("${assetPath}").default`
+      }
+
+      return match
+    },
+  )
+
+  return transformedCode
+}

--- a/tests/features/static-file-imports/resolve-static-path-string.test.ts
+++ b/tests/features/static-file-imports/resolve-static-path-string.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test"
+import { createCircuitWebWorker } from "lib"
+import { repoFileUrl } from "tests/fixtures/resourcePaths"
+
+test("should import .glb file as string URL from node_modules", async () => {
+  const circuitWebWorker = createCircuitWebWorker({
+    webWorkerUrl: repoFileUrl("dist/webworker/entrypoint.js").href,
+    platform: {
+      projectBaseUrl: "https://example.com/assets",
+    },
+  })
+
+  const worker = await circuitWebWorker
+
+  await worker.executeWithFsMap({
+    fsMap: {
+      "index.tsx": `
+import { model } from "node_modules/library/index.js";
+
+export default () => {
+  return (
+    <board width="10mm" height="10mm">
+      <resistor resistance="1k" footprint="0402" name="R1"  cadModel={
+          <cadmodel
+            modelUrl={model.glbUrl}
+          />
+        }
+      />
+    </board>
+  );
+};
+        `,
+      "node_modules/library/assets/model.glb": "__STATIC_ASSET__",
+      "node_modules/library/index.js": `
+      export const model = {
+        glbUrl: "./assets/model.glb",
+      };
+        `,
+    },
+    mainComponentPath: "index.tsx",
+  })
+
+  await worker.renderUntilSettled()
+
+  // Verify the circuit rendered successfully (imports worked)
+  const circuitJson = await worker.getCircuitJson()
+  expect(circuitJson).toBeDefined()
+
+  const cadComponent = circuitJson.find((e) => e.type === "cad_component")!
+
+  expect(cadComponent.model_glb_url).toBe(
+    "https://example.com/assets/node_modules/library/assets/model.glb",
+  )
+
+  await worker.kill()
+})

--- a/tests/util-fns/get-static-asset-paths-from-code.test.tsx
+++ b/tests/util-fns/get-static-asset-paths-from-code.test.tsx
@@ -1,0 +1,113 @@
+import { test, expect } from "bun:test"
+import { getStaticAssetPathsFromCode } from "lib/utils/get-static-asset-paths-from-code"
+
+test("extracts GLB paths from var assignments", () => {
+  const code = `
+var MachinePinMediumStandardGlbUrl = "./assets/MachinePinMediumStandard-7a4064cf.glb";
+var MachinePinMediumShortGlbUrl = "./assets/MachinePinMediumShort-f32ba626.glb";
+  `
+
+  const paths = getStaticAssetPathsFromCode(code)
+
+  expect(paths).toContain("./assets/MachinePinMediumStandard-7a4064cf.glb")
+  expect(paths).toContain("./assets/MachinePinMediumShort-f32ba626.glb")
+  expect(paths).toHaveLength(2)
+})
+
+test("extracts paths from const and let assignments", () => {
+  const code = `
+const glbUrl = "./model.glb";
+let objUrl = "./model.obj";
+var gltfUrl = "./model.gltf";
+  `
+
+  const paths = getStaticAssetPathsFromCode(code)
+
+  expect(paths).toContain("./model.glb")
+  expect(paths).toContain("./model.obj")
+  expect(paths).toContain("./model.gltf")
+  expect(paths).toHaveLength(3)
+})
+
+test("extracts paths from object property assignments", () => {
+  const code = `
+const config = {
+  glbPath: "./assets/model.glb",
+  stepPath: "./assets/model.step",
+};
+  `
+
+  const paths = getStaticAssetPathsFromCode(code)
+
+  expect(paths).toContain("./assets/model.glb")
+  expect(paths).toContain("./assets/model.step")
+  expect(paths).toHaveLength(2)
+})
+
+test("handles single quotes", () => {
+  const code = `
+var url = './assets/file.glb';
+  `
+
+  const paths = getStaticAssetPathsFromCode(code)
+
+  expect(paths).toContain("./assets/file.glb")
+})
+
+test("ignores non-static-asset paths", () => {
+  const code = `
+var name = "./SomeComponent.tsx";
+var path = "./utils/helper.js";
+var glbPath = "./assets/model.glb";
+  `
+
+  const paths = getStaticAssetPathsFromCode(code)
+
+  // Should only extract the .glb file
+  expect(paths).toContain("./assets/model.glb")
+  expect(paths).toHaveLength(1)
+})
+
+test("handles paths without leading ./", () => {
+  const code = `
+var url = "assets/model.glb";
+  `
+
+  const paths = getStaticAssetPathsFromCode(code)
+
+  expect(paths).toHaveLength(0) // Should not match paths without ./ or ../
+})
+
+test("handles relative parent paths", () => {
+  const code = `
+var url = "../assets/model.glb";
+  `
+
+  const paths = getStaticAssetPathsFromCode(code)
+
+  expect(paths).toContain("../assets/model.glb")
+})
+
+test("handles kicad_mod files", () => {
+  const code = `
+var footprint = "./footprints/resistor.kicad_mod";
+  `
+
+  const paths = getStaticAssetPathsFromCode(code)
+
+  expect(paths).toContain("./footprints/resistor.kicad_mod")
+})
+
+test("avoids duplicates", () => {
+  const code = `
+var url1 = "./model.glb";
+var url2 = "./model.glb";
+const config = {
+  glbPath: "./model.glb"
+};
+  `
+
+  const paths = getStaticAssetPathsFromCode(code)
+
+  expect(paths.filter((p) => p === "./model.glb")).toHaveLength(1)
+})


### PR DESCRIPTION
This was being skipped for path resolution as it only looks for import statement

<img width="853" height="202" alt="image" src="https://github.com/user-attachments/assets/5bfc5477-18fc-4448-94dd-39c7bbdda9ba" />
