### PR TITLE
Add tslib to pre-supplied imports

### DIFF
--- a/lib/eval/execution-context.ts
+++ b/lib/eval/execution-context.ts
@@ -7,6 +7,7 @@ import * as tscircuitMathUtils from "@tscircuit/math-utils"
 import type { PlatformConfig } from "@tscircuit/props"
 import { getPlatformConfig } from "lib/getPlatformConfig"
 import type { TsConfig } from "lib/runner/tsconfigPaths"
+import * as tslib from "tslib"
 import Debug from "debug"
 
 const debug = Debug("tsci:eval:execution-context")
@@ -79,6 +80,7 @@ export function createExecutionContext(
       react: React,
       "react/jsx-runtime": ReactJsxRuntime,
       debug: Debug,
+      tslib,
 
       // This is usually used as a type import, we can remove the shim when we
       // ignore type imports in getImportsFromCode

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "sucrase": "^3.35.0",
     "ts-expect": "^1.3.0",
     "tsup": "^8.2.4",
+    "tslib": "^2.8.1",
     "@tscircuit/common": "^0.0.20",
     "@tscircuit/copper-pour-solver": "^0.0.14"
   },

--- a/tests/features/presupplied-imports.test.ts
+++ b/tests/features/presupplied-imports.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test"
+import { CircuitRunner } from "lib/runner/CircuitRunner"
+
+test("tslib is added to pre-supplied imports", async () => {
+  const runner = new CircuitRunner()
+
+  await runner.execute(`
+    import { __assign } from "tslib"
+
+    const dimensions = __assign({ width: "10mm" }, { height: "10mm" })
+
+    circuit.add(<board {...dimensions} />)
+  `)
+
+  await runner.renderUntilSettled()
+
+  expect(runner._executionContext?.preSuppliedImports.tslib).toBeDefined()
+})


### PR DESCRIPTION
## Summary
- add tslib to the pre-supplied imports available in the execution context
- declare tslib in devDependencies for bundling
- add a feature test ensuring tslib-based helper imports resolve

## Testing
- bun test tests/features/presupplied-imports.test.ts
- bunx tsc --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692f334368a4832eb752622348093690)