### PR TITLE
Handle STEP file assets

### DIFF
--- a/lib/runner/resolveFilePath.ts
+++ b/lib/runner/resolveFilePath.ts
@@ -6,7 +6,19 @@ import {
   resolveWithBaseUrl,
 } from "./tsconfigPaths"
 
-const FILE_EXTENSIONS = ["tsx", "ts", "json", "js", "jsx", "obj", "gltf", "glb"]
+const FILE_EXTENSIONS = [
+  "tsx",
+  "ts",
+  "json",
+  "js",
+  "jsx",
+  "obj",
+  "gltf",
+  "glb",
+  "stl",
+  "step",
+  "stp",
+]
 
 export const resolveFilePath = (
   unknownFilePath: string,

--- a/lib/shared/static-asset-extensions.ts
+++ b/lib/shared/static-asset-extensions.ts
@@ -4,6 +4,8 @@ export const STATIC_ASSET_EXTENSIONS = [
   ".gltf",
   ".obj",
   ".stl",
+  ".step",
+  ".stp",
 ]
 
 export const isStaticAssetPath = (path: string) =>

--- a/tests/features/static-file-imports/static-file-import.test.ts
+++ b/tests/features/static-file-imports/static-file-import.test.ts
@@ -17,6 +17,11 @@ test("should import .glb file as string URL when projectBaseUrl is configured", 
       "index.tsx": `
 import glbUrl from "./model.glb";
 import kicadMod from "./footprint.kicad_mod";
+import stepUrl from "./model.step";
+
+if (stepUrl !== "https://example.com/assets/model.step") {
+  throw new Error("Unexpected STEP URL: " + stepUrl);
+}
 
 export default () => {
   return (
@@ -30,6 +35,7 @@ export default () => {
         `,
       "model.glb": "__STATIC_ASSET__",
       "footprint.kicad_mod": "__STATIC_ASSET__",
+      "model.step": "__STATIC_ASSET__",
     },
     mainComponentPath: "index.tsx",
   })


### PR DESCRIPTION
## Summary
- treat STEP/STP files as static assets and allow resolution during evaluation
- extend file path resolution to include STEP family extensions
- verify static STEP imports respect projectBaseUrl in worker execution

## Testing
- bunx tsc --noEmit
- bun test tests/features/static-file-imports/static-file-import.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692f35744214832ebeaf48f0128d4713)