### PR TITLE
feat: add postinstall script to synchronize core package versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tscircuit/eval",
   "main": "dist/lib/index.js",
-  "version": "0.0.519",
+  "version": "0.0.520",
   "type": "module",
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@tscircuit/eval",
   "main": "dist/lib/index.js",
-  "version": "0.0.515",
+  "version": "0.0.516",
   "type": "module",
   "files": [
     "dist"
   ],
   "scripts": {
+    "postinstall": "bun run scripts/postinstall.ts || true",
     "build": "bun run build:lib && bun run build:webworker && bun run build:blob-url && bun run build:runner && bun run build:worker-wrapper && bun run build:platform-config",
     "build:lib": "tsup-node --config tsup-lib.config.ts",
     "build:platform-config": "tsup-node --config tsup-platform-config.config.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tscircuit/eval",
   "main": "dist/lib/index.js",
-  "version": "0.0.516",
+  "version": "0.0.519",
   "type": "module",
   "files": [
     "dist"

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -1,0 +1,123 @@
+/**
+ * Postinstall script to synchronize core-related package versions
+ * with the main tscircuit core repository.
+ *
+ * This script is run after dependencies are installed to ensure
+ * that tscircuit/eval always has matching versions with @tscircuit/core.
+ */
+
+// @ts-ignore
+import corePackageJson from "@tscircuit/core/package.json"
+import currentPackageJson from "../package.json"
+
+const DO_NOT_SYNC_PACKAGE = [
+  "@biomejs/biome",
+  "@tscircuit/import-snippet",
+  "@tscircuit/layout",
+  "@tscircuit/log-soup",
+  "@tscircuit/common",
+  "@tscircuit/schematic-autolayout",
+  "@types/*",
+  "tsup",
+  "react-reconciler",
+  "react-reconciler-18",
+  "bun-match-svg",
+  "chokidar-cli",
+  "pkg-pr-new",
+  "howfat",
+  "live-server",
+  "looks-same",
+  "ts-expect",
+  "concurrently",
+  "nanoid",
+  "eecircuit-engine",
+  "@flatten-js/core",
+  "@lume/kiwi",
+  "calculate-packing",
+  "css-select",
+  "format-si-unit",
+  "performance-now",
+  "transformation-matrix",
+]
+
+try {
+  const coreDeps: any = {
+    ...corePackageJson.devDependencies,
+    ...corePackageJson.dependencies,
+  }
+
+  const currentDeps: any = {
+    ...currentPackageJson.devDependencies,
+    ...(currentPackageJson as any).dependencies,
+  }
+  const depsToUpdate: any = {}
+
+  let modifiedDeps = false
+
+  // Update dependencies to match core
+  for (const [packageName, currentVersion] of Object.entries(currentDeps)) {
+    if (packageName in coreDeps && coreDeps[packageName] !== currentVersion) {
+      console.log(
+        `Updating ${packageName} from ${currentVersion} to ${coreDeps[packageName]}`,
+      )
+      depsToUpdate[packageName] = coreDeps[packageName as keyof typeof coreDeps]
+      modifiedDeps = true
+    }
+  }
+
+  // Check for missing core dependencies
+  const missingDeps: string[] = []
+  for (const packageName of Object.keys(coreDeps)) {
+    if (
+      DO_NOT_SYNC_PACKAGE.some((dnsp) =>
+        dnsp.includes("*")
+          ? packageName.startsWith(dnsp.replace("*", ""))
+          : packageName === dnsp,
+      )
+    ) {
+      continue
+    }
+    if (!(packageName in currentDeps)) {
+      missingDeps.push(packageName)
+    }
+  }
+
+  if (missingDeps.length > 0) {
+    throw new Error(
+      `Missing core dependencies in package.json: ${missingDeps.join(", ")}. ` +
+        `\n\nAdd them to package.json or add to DO_NOT_SYNC_PACKAGE list.`,
+    )
+  }
+
+  if (modifiedDeps) {
+    // Use regex to replace the dependencies in the package.json
+    const packageJsonPath = new URL("../package.json", import.meta.url).pathname
+    // @ts-ignore Bun global
+    let packageJson = await Bun.file(packageJsonPath).text()
+    for (const [packageName, version] of Object.entries(depsToUpdate)) {
+      const pattern = `"${packageName}":\\s*"${currentDeps[packageName].replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}"(,)?`
+      packageJson = packageJson.replace(
+        new RegExp(pattern),
+        `"${packageName}": "${version}"$1`,
+      )
+    }
+    // @ts-ignore Bun global
+    await Bun.write(packageJsonPath, packageJson)
+    console.log("✓ Core versions synchronized successfully")
+  } else {
+    console.log("✓ All dependencies are already in sync with core")
+  }
+} catch (error) {
+  if (error instanceof Error) {
+    console.error(`✗ Failed to synchronize core versions: ${error.message}`)
+    if (error.message.includes("Cannot find module")) {
+      console.error(
+        "Error: @tscircuit/core package not found. Make sure dependencies are installed.",
+      )
+    }
+  } else {
+    console.error("✗ An unexpected error occurred during postinstall")
+  }
+  // @ts-ignore process global
+  process.exit(1)
+}


### PR DESCRIPTION


### Overview
Implement a postinstall script that automatically synchronizes package versions in `@tscircuit/eval` with the main `@tscircuit/core` repository, preventing version drift between the two packages.

### Changes
- **New file**: `scripts/postinstall.ts` - Postinstall script that:
  - Compares devDependencies and dependencies from both `@tscircuit/eval` and `@tscircuit/core`
  - Updates outdated package versions to match core
  - Validates that all core dependencies exist in eval (or are explicitly excluded)
  - Provides clear error messages when dependencies are missing
  - Logs successful synchronization status

- **Updated**: `package.json`
  - Added `"postinstall": "bun run scripts/postinstall.ts || true"` to scripts section
  - Script runs automatically after `bun install` (or npm/yarn equivalents)

### How It Works
1. Loads package.json files from both `@tscircuit/core` and `@tscircuit/eval`
2. Identifies version mismatches in common dependencies
3. Updates eval's package.json with core versions using regex replacement
4. Validates that no core dependencies are missing (with `DO_NOT_SYNC_PACKAGE` allowlist for exceptions)
5. Reports changes or confirms all versions are in sync

### Implementation Details

#### DO_NOT_SYNC_PACKAGE List
The following packages are excluded from synchronization (either eval-specific or not applicable):
- `@biomejs/biome` - Eval-specific linting
- `@tscircuit/import-snippet` - Eval-specific feature
- `@tscircuit/layout` - Eval-specific feature
- `@tscircuit/log-soup` - Eval-specific feature
- `@tscircuit/common` - Eval-specific feature
- `@tscircuit/schematic-autolayout` - Eval-specific feature
- `@types/*` - Type definitions (managed separately)
- `tsup` - Build tool (eval-specific)
- `react-reconciler`, `react-reconciler-18` - Eval-specific dependencies
- `bun-match-svg`, `chokidar-cli`, `pkg-pr-new`, `howfat`, `live-server`, `looks-same`, `ts-expect` - Dev/test tools
- `concurrently`, `nanoid`, `eecircuit-engine` - Eval-specific
- `@flatten-js/core`, `@lume/kiwi`, `calculate-packing`, `css-select`, `format-si-unit`, `performance-now`, `transformation-matrix` - Core-only dependencies

#### Error Handling
- **Missing dependencies**: Script validates all core dependencies exist in eval. If missing, it throws a clear error message suggesting to either add them to `package.json` or add them to the `DO_NOT_SYNC_PACKAGE` list.
- **File operations**: Uses Bun's file APIs for safe package.json manipulation
- **Graceful exit**: Script exits with code 1 on errors, preventing installation from failing with the `|| true` fallback

### Benefits
- ✅ **Automatic version synchronization** - Runs on every `bun install`
- ✅ **Prevents version drift** - Eval always matches core versions
- ✅ **Clear validation** - Reports mismatches and missing dependencies
- ✅ **Zero-config** - Works out of the box after install
- ✅ **Flexible exclusions** - `DO_NOT_SYNC_PACKAGE` list for eval-specific packages
- ✅ **Clear error messages** - Helpful guidance when issues are detected

### Testing
Script has been tested and validates successfully:
```
✓ All dependencies are already in sync with core
```

### Related Issue
Closes #357

### Checklist
- [x] Postinstall script created and functional
- [x] Package.json updated with postinstall hook
- [x] Script tested and working
- [x] Error handling implemented
- [x] Clear success/error messages provided
- [x] DO_NOT_SYNC_PACKAGE list configured appropriately

/fix #357
