### PR TITLE
fix: error message for packages which don't the entrypoint files which are generated after successful build (TSC-262)

### DIFF
--- a/lib/eval/import-eval-path.ts
+++ b/lib/eval/import-eval-path.ts
@@ -15,6 +15,7 @@ import { getNodeModuleDirectory } from "./getNodeModuleDirectory"
 import { getPackageJsonEntrypoint } from "./getPackageJsonEntrypoint"
 import { isTypeScriptEntrypoint } from "./isTypeScriptEntrypoint"
 import { isDistDirEmpty } from "./isDistDirEmpty"
+import { resolveEntrypointPath } from "./resolveEntrypointPath"
 
 const debug = Debug("tsci:eval:import-eval-path")
 
@@ -222,9 +223,18 @@ export async function importEvalPath(
       if (entrypoint?.startsWith("dist/")) {
         if (isDistDirEmpty(importName, ctx.fsMap)) {
           throw new Error(
-            `Node module "${importName}" has no files in dist, did you forget to transpile?\n\n${ctx.logger.stringifyLogs()}`,
+            `"${importName}" has no files in dist, it may not be built\n\n${ctx.logger.stringifyLogs()}`,
           )
         }
+      }
+
+      if (
+        entrypoint &&
+        !resolveEntrypointPath(importName, entrypoint, ctx.fsMap)
+      ) {
+        throw new Error(
+          `${importName}'s main path (${entrypoint}) was not found, it may not be built\n\n${ctx.logger.stringifyLogs()}`,
+        )
       }
     }
 

--- a/lib/eval/import-node-module.ts
+++ b/lib/eval/import-node-module.ts
@@ -7,6 +7,7 @@ import { getNodeModuleDirectory } from "./getNodeModuleDirectory"
 import { getPackageJsonEntrypoint } from "./getPackageJsonEntrypoint"
 import { isTypeScriptEntrypoint } from "./isTypeScriptEntrypoint"
 import { isDistDirEmpty } from "./isDistDirEmpty"
+import { resolveEntrypointPath } from "./resolveEntrypointPath"
 
 const debug = Debug("tsci:eval:import-node-module")
 
@@ -33,12 +34,15 @@ export const importNodeModule = async (
     }
   }
 
+  const nodeModuleDir = hasPackageJson
+    ? getNodeModuleDirectory(importName, fsMap)
+    : null
+
   const resolvedNodeModulePath = resolveNodeModule(importName, ctx.fsMap, "")
 
   // Only run Steps 2-4 if package exists in node_modules (after resolver attempts)
   if (hasPackageJson && resolvedNodeModulePath) {
     // Step 2: Check if node_modules directory exists for the package
-    const nodeModuleDir = getNodeModuleDirectory(importName, fsMap)
     if (!nodeModuleDir) {
       throw new Error(
         `Node module "${importName}" has no files in the node_modules directory\n\n${ctx.logger.stringifyLogs()}`,
@@ -57,13 +61,29 @@ export const importNodeModule = async (
     if (entrypoint && entrypoint.startsWith("dist/")) {
       if (isDistDirEmpty(importName, fsMap)) {
         throw new Error(
-          `Node module "${importName}" has no files in dist, did you forget to transpile?\n\n${ctx.logger.stringifyLogs()}`,
+          `"${importName}" has no files in dist, it may not be built\n\n${ctx.logger.stringifyLogs()}`,
         )
       }
     }
   }
 
   if (!resolvedNodeModulePath) {
+    if (hasPackageJson && nodeModuleDir) {
+      const entrypoint = getPackageJsonEntrypoint(importName, fsMap)
+      if (entrypoint?.startsWith("dist/")) {
+        if (isDistDirEmpty(importName, fsMap)) {
+          throw new Error(
+            `"${importName}" has no files in dist, it may not be built\n\n${ctx.logger.stringifyLogs()}`,
+          )
+        }
+      }
+      if (entrypoint && !resolveEntrypointPath(importName, entrypoint, fsMap)) {
+        throw new Error(
+          `${importName}'s main path (${entrypoint}) was not found, it may not be built\n\n${ctx.logger.stringifyLogs()}`,
+        )
+      }
+    }
+
     const platform = ctx.circuit?.platform
     if (platform?.nodeModulesResolver) {
       debug(`Attempting to resolve "${importName}" using nodeModulesResolver`)

--- a/lib/eval/import-snippet.ts
+++ b/lib/eval/import-snippet.ts
@@ -29,6 +29,22 @@ export async function importSnippet(
     return
   }
 
+  // Check if the response is a JSON error (package not built)
+  if (cjs?.startsWith("{")) {
+    try {
+      const jsonResponse = JSON.parse(cjs)
+      if (jsonResponse.ok === false && jsonResponse.error) {
+        throw new Error(
+          `"${importName}" has no files in dist, it may not be built\n\n${ctx.logger.stringifyLogs()}`,
+        )
+      }
+    } catch (e) {
+      throw new Error(
+        `Error parsing cjs response: ${e}\n\n${ctx.logger.stringifyLogs()}`,
+      )
+    }
+  }
+
   // Resolve transitive dependencies before evaluating
   const importNames = getImportsFromCode(cjs!)
 

--- a/lib/eval/resolveEntrypointPath.ts
+++ b/lib/eval/resolveEntrypointPath.ts
@@ -1,0 +1,23 @@
+import { extractBasePackageName } from "./extractBasePackageName"
+
+const moduleExtensions = [".js", ".jsx", ".ts", ".tsx", ".json"]
+
+export const resolveEntrypointPath = (
+  packageName: string,
+  entrypoint: string,
+  fsMap: Record<string, string>,
+): string | null => {
+  const basePackageName = extractBasePackageName(packageName)
+  const entrypointPath = `node_modules/${basePackageName}/${entrypoint}`
+
+  if (fsMap[entrypointPath]) {
+    return entrypointPath
+  }
+
+  for (const ext of moduleExtensions) {
+    const pathWithExt = entrypointPath.replace(/\.js$|\.jsx$/, "") + ext
+    if (fsMap[pathWithExt]) return pathWithExt
+  }
+
+  return null
+}

--- a/tests/features/throw-error-missing-main-entrypoint.test.tsx
+++ b/tests/features/throw-error-missing-main-entrypoint.test.tsx
@@ -1,0 +1,36 @@
+import { test, expect } from "bun:test"
+import { CircuitRunner } from "lib/runner/CircuitRunner"
+
+test("should throw: main path was not found, it may not be built", async () => {
+  const runner = new CircuitRunner()
+
+  await expect(
+    runner.executeWithFsMap({
+      entrypoint: "index.tsx",
+      fsMap: {
+        "package.json": JSON.stringify({
+          name: "test-project",
+          version: "1.0.0",
+          dependencies: {
+            "missing-main": "1.0.0",
+          },
+        }),
+        "index.tsx": `
+          import { something } from "missing-main"
+
+          export default () => <div>Test</div>
+        `,
+        "node_modules/missing-main/package.json": JSON.stringify({
+          name: "missing-main",
+          version: "1.0.0",
+          main: "dist/index.js",
+        }),
+        "node_modules/missing-main/dist/other.js": `
+          export const something = "value"
+        `,
+      },
+    }),
+  ).rejects.toThrow(
+    /missing-main's main path \(dist\/index\.js\) was not found, it may not be built/,
+  )
+})

--- a/tests/features/throw-error-no-files-in-dist.test.tsx
+++ b/tests/features/throw-error-no-files-in-dist.test.tsx
@@ -1,7 +1,7 @@
 import { test, expect } from "bun:test"
 import { CircuitRunner } from "lib/runner/CircuitRunner"
 
-test("should throw: Node module has no files in dist, did you forget to transpile", async () => {
+test("should throw: has no files in dist, it may not be built", async () => {
   const runner = new CircuitRunner()
 
   await expect(
@@ -31,6 +31,6 @@ test("should throw: Node module has no files in dist, did you forget to transpil
       },
     }),
   ).rejects.toThrow(
-    /Node module "dist-package" has no files in dist, did you forget to transpile\?/,
+    /"dist-package" has no files in dist, it may not be built/,
   )
 })

--- a/tests/features/throw-error-no-files-in-dist.test.tsx
+++ b/tests/features/throw-error-no-files-in-dist.test.tsx
@@ -30,7 +30,5 @@ test("should throw: has no files in dist, it may not be built", async () => {
         `,
       },
     }),
-  ).rejects.toThrow(
-    /"dist-package" has no files in dist, it may not be built/,
-  )
+  ).rejects.toThrow(/"dist-package" has no files in dist, it may not be built/)
 })


### PR DESCRIPTION
## Before
<img width="646" height="735" alt="image" src="https://github.com/user-attachments/assets/924e8360-833f-4561-94ec-8e78577faeec" />

## After
<img width="853" height="260" alt="image" src="https://github.com/user-attachments/assets/67f82718-0c4a-4bb1-9d23-e7e6c7dd312f" />
