### PR TITLE
Add #ext= fragment to blob URLs for static assets to fix STEP file detection

### DIFF
--- a/lib/eval/import-local-file.ts
+++ b/lib/eval/import-local-file.ts
@@ -82,9 +82,11 @@ export const importLocalFile = async (
             ? "text/plain"
             : "application/octet-stream",
         })
-        // Add #ext= fragment so downstream can detect file type from blob URL
-        const ext = fsPath.split(".").pop()
-        staticUrl = `${URL.createObjectURL(blob)}#ext=${ext}`
+        // Add #ext= fragment only for STEP files so downstream can detect file type
+        const ext = fsPath.split(".").pop()?.toLowerCase()
+        const isStepFile = ext === "step" || ext === "stp"
+        const blobUrl = URL.createObjectURL(blob)
+        staticUrl = isStepFile ? `${blobUrl}#ext=${ext}` : blobUrl
       }
 
       preSuppliedImports[fsPath] = {

--- a/lib/eval/import-local-file.ts
+++ b/lib/eval/import-local-file.ts
@@ -82,7 +82,9 @@ export const importLocalFile = async (
             ? "text/plain"
             : "application/octet-stream",
         })
-        staticUrl = URL.createObjectURL(blob)
+        // Add #ext= fragment so downstream can detect file type from blob URL
+        const ext = fsPath.split(".").pop()
+        staticUrl = `${URL.createObjectURL(blob)}#ext=${ext}`
       }
 
       preSuppliedImports[fsPath] = {

--- a/tests/examples/example25-step-file-blob-url-with-ext-fragment.test.tsx
+++ b/tests/examples/example25-step-file-blob-url-with-ext-fragment.test.tsx
@@ -1,0 +1,69 @@
+import { CircuitRunner, getPlatformConfig } from "lib/index"
+import { test, expect } from "bun:test"
+import type { CadComponent } from "circuit-json"
+
+test(
+  "example25-step-file-blob-url-with-ext-fragment",
+  async () => {
+    const runner = new CircuitRunner({
+      platform: {
+        ...getPlatformConfig(),
+      },
+    })
+
+    // Provide actual STEP file content (simplified header)
+    const stepFileContent = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''), '2;1');
+FILE_NAME('test.step', '2024-01-01', (''), (''), '', '', '');
+FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));
+ENDSEC;
+DATA;
+ENDSEC;
+END-ISO-10303-21;`
+
+    await runner.executeWithFsMap({
+      entrypoint: "index.tsx",
+      fsMap: {
+        "index.tsx": `
+import testStep from "./test.step"
+circuit.add(
+  <board width="10mm" height="10mm">
+    <chip
+      name="U1"
+      footprint="soic8"
+      cadModel={
+        <cadmodel modelUrl={testStep} />
+      }
+    />
+  </board>
+)
+`,
+        "test.step": stepFileContent,
+      },
+    })
+
+    await runner.renderUntilSettled()
+
+    const circuitJson = await runner.getCircuitJson()
+    expect(circuitJson).toBeDefined()
+
+    const cadModel = circuitJson.find(
+      (el: any) => el.type === "cad_component",
+    ) as CadComponent
+    expect(cadModel).toBeDefined()
+    expect(cadModel?.type).toBe("cad_component")
+
+    // model_step_url should be set (proves #ext=step fragment detection worked)
+    // Note: core strips the fragment after using it for type detection
+    expect(cadModel?.model_step_url).toBeDefined()
+    expect(cadModel?.model_step_url).toContain("blob:")
+
+    // model_stl_url should NOT be set - this was the bug before the fix
+    // (without #ext=step, core would fall back to model_stl_url)
+    expect(cadModel?.model_stl_url).toBeUndefined()
+
+    await runner.kill()
+  },
+  20 * 1000,
+)


### PR DESCRIPTION
**Before**
<img width="1440" height="820" alt="image" src="https://github.com/user-attachments/assets/a255acf3-7fa8-471f-b057-fdae57f392a6" />

**circuitjson before**
`{
    "type": "cad_component",
    "cad_component_id": "cad_component_0",
    "position": {
      "x": 0,
      "y": 0,
      "z": 0.7
    },
    "rotation": {
      "x": 0,
      "y": 0,
      "z": 0
    },
    "pcb_component_id": "pcb_component_0",
    "source_component_id": "source_component_0",
    "model_stl_url": "blob:http://localhost:5173/ee72f9d3-5cac-4492-99e5-85bc5bbb0c25"
  }`
  It was defaulting to stl url and we were getting THREE.OBJLoader warnings in the console.

**After**
<img width="954" height="532" alt="image" src="https://github.com/user-attachments/assets/084a0435-9824-412e-8b60-17d2c97e34ff" />


**circuitjson after:** 
`{
    "type": "cad_component",
    "cad_component_id": "cad_component_0",
    "position": {
      "x": 0,
      "y": 0,
      "z": 0.7
    },
    "rotation": {
      "x": 0,
      "y": 0,
      "z": 0
    },
    "pcb_component_id": "pcb_component_0",
    "source_component_id": "source_component_0",
    "model_step_url": "blob:http://localhost:5173/cac93b56-8fc7-4fb8-9cb8-be44fbf9709b#ext=step"
  }`