### PR TITLE
Improve KiCad footprint loader errors and add STEP model URL

### DIFF
--- a/tests/features/kicad-footprint-load-error-message.test.tsx
+++ b/tests/features/kicad-footprint-load-error-message.test.tsx
@@ -1,0 +1,67 @@
+import { CircuitRunner } from "lib/runner/CircuitRunner"
+import { expect, test } from "bun:test"
+import { getPlatformConfig } from "lib/getPlatformConfig"
+
+test(
+  "kicad footprint load errors include HTTP status and URL",
+  async () => {
+    const runner = new CircuitRunner()
+
+    await runner.execute(`
+    circuit.add(
+      <board width="10mm" height="10mm">
+        <chip
+          name="U1"
+          footprint="kicad:Connector_JST/JST_SH_BM02B-SRSS-TB_1x02_1MP_P1.00mm_Vertical"
+        />
+      </board>
+    )
+  `)
+
+    await runner.renderUntilSettled()
+
+    const circuitJson = await runner.getCircuitJson()
+    const error = circuitJson.find(
+      (el) => el.type === "external_footprint_load_error",
+    )
+
+    expect(error).toBeDefined()
+    expect((error as any).message).toContain("HTTP 404")
+    expect((error as any).message).toContain(
+      "https://kicad-mod-cache.tscircuit.com/Connector_JST/JST_SH_BM02B-SRSS-TB_1x02_1MP_P1.00mm_Vertical.circuit.json",
+    )
+
+    await runner.kill()
+  },
+  20 * 1000,
+)
+
+test("kicad footprint library includes both WRL and STEP model URLs", async () => {
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = (async () => {
+    return new Response(JSON.stringify([]), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })
+  }) as unknown as typeof fetch
+
+  try {
+    const platformConfig = getPlatformConfig()
+    const kicadLoader = platformConfig.footprintLibraryMap?.kicad as (
+      name: string,
+    ) => Promise<any>
+
+    const result = await kicadLoader(
+      "Connector_JST/JST_SH_BM02B-SRSS-TB_1x02_1MP_P1.00mm_Vertical",
+    )
+
+    expect(result.cadModel.wrlUrl).toBe(
+      "https://kicad-mod-cache.tscircuit.com/Connector_JST/JST_SH_BM02B-SRSS-TB_1x02_1MP_P1.00mm_Vertical.wrl",
+    )
+    expect(result.cadModel.stepUrl).toBe(
+      "https://kicad-mod-cache.tscircuit.com/Connector_JST/JST_SH_BM02B-SRSS-TB_1x02_1MP_P1.00mm_Vertical.step",
+    )
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})


### PR DESCRIPTION
### Motivation
- Make KiCad footprint load failures easier to diagnose by surfacing HTTP status, the request URL, and a short response preview. 
- Ensure CAD model metadata includes both WRL and STEP URLs so consumers can access either format. 
- Harden JSON handling for footprint responses to avoid unhandled parse errors and to normalize single-object responses to arrays.

### Description
- Update the `footprintLibraryMap.kicad` loader in `getPlatformConfig` to check `res.ok` and throw an error containing the HTTP status, the `circuitJsonUrl`, and a short body preview when the request fails. 
- Wrap `res.json()` in a `try/catch` and throw a clear parse error when JSON decoding fails. 
- Normalize the fetched `raw` payload into an array before filtering and ensure the returned `cadModel` includes both `wrlUrl` and a new `stepUrl` (keeping `modelUnitToMmScale`). 
- Add `tests/features/kicad-footprint-load-error-message.test.tsx` with two tests that verify error content includes HTTP status and URL and that the loader returns both `wrlUrl` and `stepUrl`.

### Testing
- Ran the new tests in `tests/features/kicad-footprint-load-error-message.test.tsx` via the test runner and both tests passed. 
- The tests exercise both a simulated HTTP 404 footprint load and a mocked successful JSON response to validate loader behavior and output shape.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a22afd5cd0832e9c6314020757b71e)