### PR TITLE
Fix inline JSX // comments breaking circuit evaluation

### DIFF
--- a/lib/transpile/transform-with-sucrase.ts
+++ b/lib/transpile/transform-with-sucrase.ts
@@ -8,6 +8,9 @@ const TYPE_STAR_EXPORT_REGEX =
 const stripTypeStarExports = (code: string) =>
   code.replace(TYPE_STAR_EXPORT_REGEX, "")
 
+const stripTrailingJsxLineComments = (code: string) =>
+  code.replace(/^((?:[^"'`\r\n]|"[^"\\]*(?:\\.[^"\\]*)*"|'[^'\\]*(?:\\.[^'\\]*)*'|`[^`\\]*(?:\\.[^`\\]*)*`)*>)\s*\/\/.*$/gm, '$1')
+
 const stripQueryAndHash = (filePath: string) => {
   const queryIndex = filePath.indexOf("?")
   const hashIndex = filePath.indexOf("#")
@@ -63,7 +66,9 @@ const getTransformsForFilePath = (filePath: string) => {
 
 export const transformWithSucrase = (code: string, filePath: string) => {
   const transforms = getTransformsForFilePath(filePath)
-  const sanitizedCode = stripTypeStarExports(code)
+  const sanitizedCode = stripTrailingJsxLineComments(
+    stripTypeStarExports(code),
+  )
   const { code: transformedCode } = transform(sanitizedCode, {
     filePath,
     production: true,

--- a/lib/transpile/transform-with-sucrase.ts
+++ b/lib/transpile/transform-with-sucrase.ts
@@ -9,7 +9,10 @@ const stripTypeStarExports = (code: string) =>
   code.replace(TYPE_STAR_EXPORT_REGEX, "")
 
 const stripTrailingJsxLineComments = (code: string) =>
-  code.replace(/^((?:[^"'`\r\n]|"[^"\\]*(?:\\.[^"\\]*)*"|'[^'\\]*(?:\\.[^'\\]*)*'|`[^`\\]*(?:\\.[^`\\]*)*`)*>)\s*\/\/.*$/gm, '$1')
+  code.replace(
+    /^((?:[^"'`\r\n]|"[^"\\]*(?:\\.[^"\\]*)*"|'[^'\\]*(?:\\.[^'\\]*)*'|`[^`\\]*(?:\\.[^`\\]*)*`)*>)\s*\/\/.*$/gm,
+    "$1",
+  )
 
 const stripQueryAndHash = (filePath: string) => {
   const queryIndex = filePath.indexOf("?")
@@ -66,9 +69,7 @@ const getTransformsForFilePath = (filePath: string) => {
 
 export const transformWithSucrase = (code: string, filePath: string) => {
   const transforms = getTransformsForFilePath(filePath)
-  const sanitizedCode = stripTrailingJsxLineComments(
-    stripTypeStarExports(code),
-  )
+  const sanitizedCode = stripTrailingJsxLineComments(stripTypeStarExports(code))
   const { code: transformedCode } = transform(sanitizedCode, {
     filePath,
     production: true,

--- a/tests/repros/jsx-inline-comment-after-component.test.tsx
+++ b/tests/repros/jsx-inline-comment-after-component.test.tsx
@@ -27,7 +27,8 @@ test("inline line comments after opening jsx tags do not create text nodes", asy
   `)
 
   const resistor = circuitJson.find(
-    (element) => element.type === "source_component" && element.name === "R-open",
+    (element) =>
+      element.type === "source_component" && element.name === "R-open",
   )
 
   expect(resistor).toBeDefined()
@@ -117,10 +118,12 @@ test("multiple jsx lines with trailing comments still render", async () => {
   `)
 
   const resistor = circuitJson.find(
-    (element) => element.type === "source_component" && element.name === "R-multi",
+    (element) =>
+      element.type === "source_component" && element.name === "R-multi",
   )
   const capacitor = circuitJson.find(
-    (element) => element.type === "source_component" && element.name === "C-multi",
+    (element) =>
+      element.type === "source_component" && element.name === "C-multi",
   )
 
   expect(resistor).toBeDefined()

--- a/tests/repros/jsx-inline-comment-after-component.test.tsx
+++ b/tests/repros/jsx-inline-comment-after-component.test.tsx
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test"
+import { runTscircuitCode } from "lib/runner"
+
+test("inline line comments after jsx components do not create text nodes", async () => {
+  const circuitJson = await runTscircuitCode(`
+    export default () => (
+      <board width="10mm" height="10mm">
+        <resistor name="R1" resistance="1k" /> // hi
+      </board>
+    )
+  `)
+
+  const resistor = circuitJson.find(
+    (element) => element.type === "source_component" && element.name === "R1",
+  )
+
+  expect(resistor).toBeDefined()
+})

--- a/tests/repros/jsx-inline-comment-after-component.test.tsx
+++ b/tests/repros/jsx-inline-comment-after-component.test.tsx
@@ -16,3 +16,113 @@ test("inline line comments after jsx components do not create text nodes", async
 
   expect(resistor).toBeDefined()
 })
+
+test("inline line comments after opening jsx tags do not create text nodes", async () => {
+  const circuitJson = await runTscircuitCode(`
+    export default () => (
+      <board width="10mm" height="10mm"> // board
+        <resistor name="R-open" resistance="1k" />
+      </board>
+    )
+  `)
+
+  const resistor = circuitJson.find(
+    (element) => element.type === "source_component" && element.name === "R-open",
+  )
+
+  expect(resistor).toBeDefined()
+})
+
+test("double slashes inside jsx string props are preserved", async () => {
+  const circuitJson = await runTscircuitCode(`
+    export default () => (
+      <board width="10mm" height="10mm">
+        <resistor name={"https://example.com/R1"} resistance="1k" /> // note
+      </board>
+    )
+  `)
+
+  const resistor = circuitJson.find(
+    (element) =>
+      element.type === "source_component" &&
+      element.name === "https://example.com/R1",
+  )
+
+  expect(resistor).toBeDefined()
+})
+
+test("double slashes in template literal props are preserved", async () => {
+  const circuitJson = await runTscircuitCode(`
+    export default () => (
+      <board width="10mm" height="10mm">
+        <resistor name={\`https://example.com/R2\`} resistance="1k" />
+      </board>
+    )
+  `)
+
+  const resistor = circuitJson.find(
+    (element) =>
+      element.type === "source_component" &&
+      element.name === "https://example.com/R2",
+  )
+
+  expect(resistor).toBeDefined()
+})
+
+test("double slashes in variable assigned props are preserved", async () => {
+  const circuitJson = await runTscircuitCode(`
+    const name = "https://example.com/R3"
+    export default () => (
+      <board width="10mm" height="10mm">
+        <resistor name={name} resistance="1k" />
+      </board>
+    )
+  `)
+
+  const resistor = circuitJson.find(
+    (element) =>
+      element.type === "source_component" &&
+      element.name === "https://example.com/R3",
+  )
+
+  expect(resistor).toBeDefined()
+})
+
+test("normal js line comments remain unaffected", async () => {
+  const circuitJson = await runTscircuitCode(`
+    const resistorName = "R-js" // regular js comment
+
+    export default () => (
+      <board width="10mm" height="10mm">
+        <resistor name={resistorName} resistance="1k" />
+      </board>
+    )
+  `)
+
+  const resistor = circuitJson.find(
+    (element) => element.type === "source_component" && element.name === "R-js",
+  )
+
+  expect(resistor).toBeDefined()
+})
+
+test("multiple jsx lines with trailing comments still render", async () => {
+  const circuitJson = await runTscircuitCode(`
+    export default () => (
+      <board width="10mm" height="10mm">
+        <resistor name="R-multi" resistance="1k" /> // resistor
+        <capacitor name="C-multi" capacitance="10uF" /> // capacitor
+      </board>
+    )
+  `)
+
+  const resistor = circuitJson.find(
+    (element) => element.type === "source_component" && element.name === "R-multi",
+  )
+  const capacitor = circuitJson.find(
+    (element) => element.type === "source_component" && element.name === "C-multi",
+  )
+
+  expect(resistor).toBeDefined()
+  expect(capacitor).toBeDefined()
+})


### PR DESCRIPTION
**Motivation**
Inline // comments after JSX tags currently create stray text nodes and crash evaluation with “Expected a React component but received text”. 

<img width="1680" height="401" alt="image" src="https://github.com/user-attachments/assets/66b47711-6940-452e-8db8-1c69860a6c58" />


**Fix:**
This patch strips trailing line comments after JSX elements so common debugging notes don’t break circuits, making the editor more forgiving and reducing confusing runtime errors.