### PR TITLE
Fix package entrypoint resolution in eval

### DIFF
--- a/lib/eval/resolveEntrypointPath.ts
+++ b/lib/eval/resolveEntrypointPath.ts
@@ -1,4 +1,5 @@
 import { extractBasePackageName } from "./extractBasePackageName"
+import { normalizePackageEntrypoint } from "lib/utils/normalize-package-entrypoint"
 
 const moduleExtensions = [".js", ".jsx", ".ts", ".tsx", ".json"]
 
@@ -8,7 +9,8 @@ export const resolveEntrypointPath = (
   fsMap: Record<string, string>,
 ): string | null => {
   const basePackageName = extractBasePackageName(packageName)
-  const entrypointPath = `node_modules/${basePackageName}/${entrypoint}`
+  const normalizedEntrypoint = normalizePackageEntrypoint(entrypoint)
+  const entrypointPath = `node_modules/${basePackageName}/${normalizedEntrypoint}`
 
   if (fsMap[entrypointPath]) {
     return entrypointPath

--- a/lib/transpile/transform-with-sucrase.ts
+++ b/lib/transpile/transform-with-sucrase.ts
@@ -66,6 +66,7 @@ export const transformWithSucrase = (code: string, filePath: string) => {
   const sanitizedCode = stripTypeStarExports(code)
   const { code: transformedCode } = transform(sanitizedCode, {
     filePath,
+    disableESTransforms: true,
     production: true,
     transforms,
   })

--- a/lib/utils/normalize-package-entrypoint.ts
+++ b/lib/utils/normalize-package-entrypoint.ts
@@ -1,0 +1,2 @@
+export const normalizePackageEntrypoint = (entrypoint: string) =>
+  entrypoint.replace(/^\.\//, "")

--- a/lib/utils/resolve-node-module.ts
+++ b/lib/utils/resolve-node-module.ts
@@ -1,4 +1,5 @@
 import { dirname } from "./dirname"
+import { normalizePackageEntrypoint } from "./normalize-package-entrypoint"
 
 type ExportValue = string | Record<string, string | Record<string, string>>
 
@@ -130,7 +131,9 @@ function resolvePackageEntryPoint(
   packageJson: PackageJson,
   ctx: NodeResolutionContext,
 ): string | null {
-  const entryPoint = packageJson.module || packageJson.main || "index.js"
+  const entryPoint = normalizePackageEntrypoint(
+    packageJson.module || packageJson.main || "index.js",
+  )
   const fullPath = `${nodeModulesPath}/${entryPoint}`
   return tryResolveWithExtensions(fullPath, ctx)
 }

--- a/tests/node-resolution/node-module-resolution-1.test.tsx
+++ b/tests/node-resolution/node-module-resolution-1.test.tsx
@@ -29,4 +29,40 @@ describe("node module resolution", () => {
     expect(resistor.resistance).toBe(1000)
     expect(resistor.name).toBe("R1")
   })
+
+  test("resolves package main entrypoints with leading ./", async () => {
+    const circuitJson = await runTscircuitCode(
+      {
+        "node_modules/test-package/package.json": JSON.stringify({
+          name: "test-package",
+          main: "./dist/index.js",
+        }),
+        "node_modules/test-package/dist/index.js": `
+          class Base {}
+          class Child extends Base {
+            value = 1
+            constructor() {
+              super(), this.value = 2
+            }
+          }
+
+          export const resistorName = new Child().value === 2 ? "R2" : "BAD"
+          export const resistanceValue = "2k"
+        `,
+        "user-code.tsx": `
+          import { resistorName, resistanceValue } from "test-package"
+          export default () => (<resistor name={resistorName} resistance={resistanceValue} />)
+        `,
+      },
+      {
+        mainComponentPath: "user-code",
+      },
+    )
+
+    const resistor = circuitJson.find(
+      (element) => element.type === "source_component" && element.name === "R2",
+    ) as any
+    expect(resistor).toBeDefined()
+    expect(resistor.resistance).toBe(2000)
+  })
 })


### PR DESCRIPTION
## Summary
- normalize package `main`/`module` paths before resolving them in the virtual fs map
- stop Sucrase from downleveling modern JS in built `.js` bundles so autorouter output evaluates correctly
- add a regression test for `main: "./dist/index.js"` packages

## Testing
- `bun test tests/node-resolution/node-module-resolution-1.test.tsx`
- `bunx tsc --noEmit`