### PR TITLE
Prefer browser entrypoints when resolving node modules in the eval runtime

### DIFF
--- a/lib/eval/getPackageJsonEntrypoint.ts
+++ b/lib/eval/getPackageJsonEntrypoint.ts
@@ -15,8 +15,14 @@ export function getPackageJsonEntrypoint(
 
   try {
     const packageJson = JSON.parse(packageJsonContent)
-    // Try main, module, or exports field (in order of preference)
-    return packageJson.main || packageJson.module || null
+    // Prefer the browser build when provided because eval runs in a browser-like
+    // environment and many CommonJS main files require Node built-ins.
+    return (
+      (typeof packageJson.browser === "string" && packageJson.browser) ||
+      packageJson.module ||
+      packageJson.main ||
+      null
+    )
   } catch {
     return null
   }

--- a/lib/utils/get-imports-from-code.ts
+++ b/lib/utils/get-imports-from-code.ts
@@ -5,7 +5,7 @@ export const getImportsFromCode = (code: string): string[] => {
   // Match basic import patterns including combined default and namespace imports
   // This regex handles both regular multi-line code and minified single-line code
   const importRegex =
-    /(?:^|;)\s*import\s*(?:(?:[\w]+\s*,\s*)?(?:\*\s+as\s+[\w]+|\{[^}]+\}|[\w]+)\s*from\s*)?['"]([^'"]+)['"]/gm
+    /(?:^|[;\n\r}])\s*import\s*(?:(?:[\w$]+\s*,\s*)?(?:\*\s+as\s+[\w$]+|\{[^}]+\}|[\w$]+)\s*from\s*)?['"]([^'"]+)['"]/gm
   const imports: string[] = []
   let match: RegExpExecArray | null
 

--- a/lib/utils/resolve-node-module.ts
+++ b/lib/utils/resolve-node-module.ts
@@ -6,6 +6,7 @@ type ExportValue = string | Record<string, string | Record<string, string>>
 interface PackageJson {
   main?: string
   module?: string
+  browser?: string | Record<string, string | false>
   exports?: Record<string, ExportValue>
 }
 
@@ -132,7 +133,10 @@ function resolvePackageEntryPoint(
   ctx: NodeResolutionContext,
 ): string | null {
   const entryPoint = normalizePackageEntrypoint(
-    packageJson.module || packageJson.main || "index.js",
+    (typeof packageJson.browser === "string" && packageJson.browser) ||
+      packageJson.module ||
+      packageJson.main ||
+      "index.js",
   )
   const fullPath = `${nodeModulesPath}/${entryPoint}`
   return tryResolveWithExtensions(fullPath, ctx)

--- a/tests/node-resolution/node-module-resolution-7.test.tsx
+++ b/tests/node-resolution/node-module-resolution-7.test.tsx
@@ -2,6 +2,43 @@ import { describe, expect, test } from "bun:test"
 import { runTscircuitCode } from "lib/runner"
 
 describe("node module resolution", () => {
+  test("resolves minified imports that depend on browser package entrypoints", async () => {
+    const circuitJson = await runTscircuitCode(
+      {
+        "node_modules/parent-package/package.json": JSON.stringify({
+          name: "parent-package",
+          main: "dist/index.js",
+        }),
+        "node_modules/parent-package/dist/index.js": `
+          class ParentPackage{}import { resistorName } from "browser-entry-package";
+          export { resistorName }
+        `,
+        "node_modules/browser-entry-package/package.json": JSON.stringify({
+          name: "browser-entry-package",
+          main: "./index.js",
+          browser: "./dist/browser.js",
+        }),
+        "node_modules/browser-entry-package/dist/browser.js": `
+          export const resistorName = "R_BROWSER"
+        `,
+        "user-code.tsx": `
+          import { resistorName } from "parent-package"
+          export default () => (<resistor name={resistorName} resistance="1k" />)
+        `,
+      },
+      {
+        mainComponentPath: "user-code",
+      },
+    )
+
+    const resistor = circuitJson.find(
+      (element) =>
+        element.type === "source_component" && element.name === "R_BROWSER",
+    ) as any
+    expect(resistor).toBeDefined()
+    expect(resistor.resistance).toBe(1000)
+  })
+
   test.skip("resolves nested node_modules packages", async () => {
     const circuitJson = await runTscircuitCode(
       {

--- a/tests/util-fns/get-imports-from-code.test.tsx
+++ b/tests/util-fns/get-imports-from-code.test.tsx
@@ -76,6 +76,11 @@ test("getImportsFromCode should handle dynamic imports", () => {
   `)
 })
 
+test("getImportsFromCode should handle minified static imports after declarations", () => {
+  const sourceCode = `class PackageExports{}import objectHash from "object-hash";`
+  expect(getImportsFromCode(sourceCode)).toEqual(["object-hash"])
+})
+
 test("getImportsFromCode should handle comments and commented imports", () => {
   const sourceCode = `
     // import foo from './commented'


### PR DESCRIPTION
## Summary
- Broaden static import scanning so minified `}import ...` forms are detected
- Prefer browser entrypoints when resolving node modules in the eval runtime
- Add regression tests for the import scanner and browser-entry module resolution

## Testing
- `bun test tests/util-fns/get-imports-from-code.test.tsx`
- `bun test tests/node-resolution/node-module-resolution-7.test.tsx`