### PR TITLE
Bundle manifold WASM for copper pour browser worker

### DIFF
--- a/assets.d.ts
+++ b/assets.d.ts
@@ -1,0 +1,4 @@
+declare module "*.wasm" {
+  const url: string
+  export default url
+}

--- a/browser-tests/browser.test.ts
+++ b/browser-tests/browser.test.ts
@@ -1,4 +1,3 @@
-import { spawn } from "node:child_process"
 import { createServer, type Server } from "node:http"
 import { expect, test } from "@playwright/test"
 
@@ -116,4 +115,17 @@ test("usb_c connector renders without CORS errors", async ({ page }) => {
   } finally {
     proxyServer.close()
   }
+})
+
+test("copper pour successfully renders in browser (verifies manifold-3d WASM)", async ({
+  page,
+}) => {
+  await new Promise((resolve) => setTimeout(resolve, 1000))
+  await page.goto("http://localhost:3070?test_to_run=copperpour")
+
+  // The output div should show success if WASM initialization and rendering worked
+  await expect(page.locator("#output")).toContainText(
+    "Success: Copper pour initialized.",
+    { timeout: 15000 },
+  )
 })

--- a/browser-tests/browsertest.ts
+++ b/browser-tests/browsertest.ts
@@ -1,7 +1,15 @@
 import { createCircuitWebWorker } from "lib/worker"
+import { convertCircuitJsonToPcbSvg } from "circuit-to-svg"
 import { runUsbCConnectorTest } from "./runUsbCConnectorTest"
 // @ts-ignore
 import blobUrl from "../dist/blob-url"
+
+function showPcbCircuit(circuitJson: any[]) {
+  const previewDiv = document.getElementById("circuit-preview")
+  if (!previewDiv) return
+
+  previewDiv.innerHTML = convertCircuitJsonToPcbSvg(circuitJson)
+}
 
 async function runDefaultTest() {
   try {
@@ -31,6 +39,7 @@ async function runDefaultTest() {
 
     // Get the circuit JSON
     const circuitJson = await circuitWebWorker.getCircuitJson()
+    showPcbCircuit(circuitJson)
 
     // Validate the circuit elements
     const resistor = circuitJson.find((el: any) => el.name === "R1")
@@ -86,6 +95,7 @@ async function runNgspiceTest() {
     await circuitWebWorker.renderUntilSettled()
 
     const circuitJson = await circuitWebWorker.getCircuitJson()
+    showPcbCircuit(circuitJson)
 
     const simGraph = circuitJson.some(
       (el) => el.type === "simulation_transient_voltage_graph",
@@ -106,6 +116,53 @@ async function runNgspiceTest() {
   }
 }
 
+async function runCopperPourTest() {
+  const outputDiv = document.getElementById("output")!
+  try {
+    console.log("creating worker for copper pour test...")
+    const circuitWebWorker = await createCircuitWebWorker({
+      webWorkerBlobUrl: blobUrl,
+      verbose: true,
+    })
+
+    console.log("worker created, executing copper pour...")
+
+    let capturedError: string | null = null
+    circuitWebWorker.on("asyncEffect:end", (event: any) => {
+      if (event.error) {
+        capturedError = `[${event.phase}] ${event.error}`
+      }
+    })
+
+    await circuitWebWorker.execute(`
+    circuit.add(
+      <board width="10mm" height="10mm">
+      <resistor name="R1" footprint="0403" />
+        <copperpour connectsTo="net.GND" layer="top" clearance="0.15mm" />
+      </board>
+    )
+  `)
+
+    await circuitWebWorker.renderUntilSettled()
+    const circuitJson = await circuitWebWorker.getCircuitJson()
+    showPcbCircuit(circuitJson)
+    const errors = circuitJson.filter(
+      (el: any) => el.type === "pcb_component_error" || el.type === "pcb_error",
+    )
+
+    if (capturedError) {
+      outputDiv.textContent = "Fail: " + capturedError
+    } else if (errors.length > 0) {
+      outputDiv.textContent = "Fail: " + (errors[0] as any).message
+    } else {
+      outputDiv.textContent = "Success: Copper pour initialized."
+    }
+  } catch (error: any) {
+    outputDiv.textContent = "Fail: Test error occurred: " + error.toString()
+    console.error("Test failed with error:", error)
+  }
+}
+
 // Run the test when the page loads
 window.addEventListener("DOMContentLoaded", () => {
   const urlParams = new URLSearchParams(window.location.search)
@@ -113,6 +170,8 @@ window.addEventListener("DOMContentLoaded", () => {
 
   if (test_to_run === "ngspice") {
     runNgspiceTest()
+  } else if (test_to_run === "copperpour") {
+    runCopperPourTest()
   } else if (test_to_run === "usb_c_connector") {
     runUsbCConnectorTest(blobUrl)
   } else {

--- a/browser-tests/browsertest.ts
+++ b/browser-tests/browsertest.ts
@@ -137,7 +137,7 @@ async function runCopperPourTest() {
     await circuitWebWorker.execute(`
     circuit.add(
       <board width="10mm" height="10mm">
-      <resistor name="R1" footprint="0403" />
+        <resistor name="R1" resistance="1k" footprint="0402" />
         <copperpour connectsTo="net.GND" layer="top" clearance="0.15mm" />
       </board>
     )

--- a/browser-tests/browsertest.ts
+++ b/browser-tests/browsertest.ts
@@ -1,15 +1,8 @@
 import { createCircuitWebWorker } from "lib/worker"
-import { convertCircuitJsonToPcbSvg } from "circuit-to-svg"
+import { runCopperPourTest } from "./runCopperPourTest"
 import { runUsbCConnectorTest } from "./runUsbCConnectorTest"
 // @ts-ignore
 import blobUrl from "../dist/blob-url"
-
-function showPcbCircuit(circuitJson: any[]) {
-  const previewDiv = document.getElementById("circuit-preview")
-  if (!previewDiv) return
-
-  previewDiv.innerHTML = convertCircuitJsonToPcbSvg(circuitJson)
-}
 
 async function runDefaultTest() {
   try {
@@ -39,7 +32,6 @@ async function runDefaultTest() {
 
     // Get the circuit JSON
     const circuitJson = await circuitWebWorker.getCircuitJson()
-    showPcbCircuit(circuitJson)
 
     // Validate the circuit elements
     const resistor = circuitJson.find((el: any) => el.name === "R1")
@@ -95,7 +87,6 @@ async function runNgspiceTest() {
     await circuitWebWorker.renderUntilSettled()
 
     const circuitJson = await circuitWebWorker.getCircuitJson()
-    showPcbCircuit(circuitJson)
 
     const simGraph = circuitJson.some(
       (el) => el.type === "simulation_transient_voltage_graph",
@@ -116,53 +107,6 @@ async function runNgspiceTest() {
   }
 }
 
-async function runCopperPourTest() {
-  const outputDiv = document.getElementById("output")!
-  try {
-    console.log("creating worker for copper pour test...")
-    const circuitWebWorker = await createCircuitWebWorker({
-      webWorkerBlobUrl: blobUrl,
-      verbose: true,
-    })
-
-    console.log("worker created, executing copper pour...")
-
-    let capturedError: string | null = null
-    circuitWebWorker.on("asyncEffect:end", (event: any) => {
-      if (event.error) {
-        capturedError = `[${event.phase}] ${event.error}`
-      }
-    })
-
-    await circuitWebWorker.execute(`
-    circuit.add(
-      <board width="10mm" height="10mm">
-        <resistor name="R1" resistance="1k" footprint="0402" />
-        <copperpour connectsTo="net.GND" layer="top" clearance="0.15mm" />
-      </board>
-    )
-  `)
-
-    await circuitWebWorker.renderUntilSettled()
-    const circuitJson = await circuitWebWorker.getCircuitJson()
-    showPcbCircuit(circuitJson)
-    const errors = circuitJson.filter(
-      (el: any) => el.type === "pcb_component_error" || el.type === "pcb_error",
-    )
-
-    if (capturedError) {
-      outputDiv.textContent = "Fail: " + capturedError
-    } else if (errors.length > 0) {
-      outputDiv.textContent = "Fail: " + (errors[0] as any).message
-    } else {
-      outputDiv.textContent = "Success: Copper pour initialized."
-    }
-  } catch (error: any) {
-    outputDiv.textContent = "Fail: Test error occurred: " + error.toString()
-    console.error("Test failed with error:", error)
-  }
-}
-
 // Run the test when the page loads
 window.addEventListener("DOMContentLoaded", () => {
   const urlParams = new URLSearchParams(window.location.search)
@@ -171,7 +115,7 @@ window.addEventListener("DOMContentLoaded", () => {
   if (test_to_run === "ngspice") {
     runNgspiceTest()
   } else if (test_to_run === "copperpour") {
-    runCopperPourTest()
+    runCopperPourTest(blobUrl)
   } else if (test_to_run === "usb_c_connector") {
     runUsbCConnectorTest(blobUrl)
   } else {

--- a/browser-tests/runCopperPourTest.ts
+++ b/browser-tests/runCopperPourTest.ts
@@ -1,0 +1,47 @@
+import { createCircuitWebWorker } from "lib/worker"
+
+export async function runCopperPourTest(blobUrl: string) {
+  const outputDiv = document.getElementById("output")!
+  try {
+    console.log("creating worker for copper pour test...")
+    const circuitWebWorker = await createCircuitWebWorker({
+      webWorkerBlobUrl: blobUrl,
+      verbose: true,
+    })
+
+    console.log("worker created, executing copper pour...")
+
+    let capturedError: string | null = null
+    circuitWebWorker.on("asyncEffect:end", (event: any) => {
+      if (event.error) {
+        capturedError = `[${event.phase}] ${event.error}`
+      }
+    })
+
+    await circuitWebWorker.execute(`
+    circuit.add(
+      <board width="10mm" height="10mm">
+        <resistor name="R1" resistance="1k" footprint="0402" />
+        <copperpour connectsTo="net.GND" layer="top" clearance="0.15mm" />
+      </board>
+    )
+  `)
+
+    await circuitWebWorker.renderUntilSettled()
+    const circuitJson = await circuitWebWorker.getCircuitJson()
+    const errors = circuitJson.filter(
+      (el: any) => el.type === "pcb_component_error" || el.type === "pcb_error",
+    )
+
+    if (capturedError) {
+      outputDiv.textContent = "Fail: " + capturedError
+    } else if (errors.length > 0) {
+      outputDiv.textContent = "Fail: " + (errors[0] as any).message
+    } else {
+      outputDiv.textContent = "Success: Copper pour initialized."
+    }
+  } catch (error: any) {
+    outputDiv.textContent = "Fail: Test error occurred: " + error.toString()
+    console.error("Test failed with error:", error)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@tscircuit/circuit-json-flex": "^0.0.3",
     "@tscircuit/circuit-json-util": "^0.0.94",
     "@tscircuit/common": "^0.0.20",
-    "@tscircuit/copper-pour-solver": "^0.0.29",
+    "@tscircuit/copper-pour-solver": "^0.0.30",
     "@tscircuit/core": "^0.0.1215",
     "@tscircuit/footprinter": "^0.0.351",
     "@tscircuit/import-snippet": "^0.0.4",

--- a/tsup-webworker.config.ts
+++ b/tsup-webworker.config.ts
@@ -20,6 +20,10 @@ export default defineConfig({
   clean: true,
   dts: true,
   esbuildOptions(options) {
+    options.loader = {
+      ...options.loader,
+      ".wasm": "dataurl",
+    }
     options.minifySyntax = true
     options.minifyWhitespace = true
     options.minifyIdentifiers = false

--- a/webworker/entrypoint.ts
+++ b/webworker/entrypoint.ts
@@ -11,13 +11,16 @@ import { importEvalPath } from "lib/eval"
 import { normalizeFsMap } from "lib/runner/normalizeFsMap"
 import { getTsConfig } from "lib/runner/tsconfigPaths"
 import type { RootCircuit } from "@tscircuit/core"
+import { setWasmUrl } from "manifold-3d/lib/wasm.js"
 import { setupDefaultEntrypointIfNeeded } from "lib/runner/setupDefaultEntrypointIfNeeded"
 import { enhanceRootCircuitHasNoChildrenError } from "lib/utils/enhance-root-circuit-error"
 import { setupFetchProxy } from "./fetchProxy"
 import { setValueAtPath } from "lib/shared/obj-path"
+import manifoldWasmUrl from "manifold-3d/manifold.wasm"
 
 globalThis.React = React
 setupFetchProxy()
+setWasmUrl(manifoldWasmUrl)
 
 // Polyfill for Node.js global object in browser workers
 // Needed because @tscircuit/core and dependencies reference global.debugGraphics/debugOutputArray


### PR DESCRIPTION
 Embeds manifold.wasm as a data URL in the browser worker and sets it explicitly with setWasmUrl, fixing copper pour rendering from blob workers where Manifold cannot resolve the WASM URL.