### PR TITLE
Add unpkg fallback for worker CDN fetch

### DIFF
--- a/lib/worker.ts
+++ b/lib/worker.ts
@@ -17,6 +17,42 @@ declare global {
   var TSCIRCUIT_GLOBAL_CIRCUIT_WORKER: CircuitWebWorker | undefined
 }
 
+export const getWebWorkerEntrypointCdnUrls = (evalVersion = "latest") => [
+  `https://cdn.jsdelivr.net/npm/@tscircuit/eval@${evalVersion}/dist/webworker/entrypoint.js`,
+  `https://unpkg.com/@tscircuit/eval@${evalVersion}/dist/webworker/entrypoint.js`,
+]
+
+export const fetchWebWorkerEntrypointBlobFromCdn = async (
+  evalVersion = "latest",
+  verbose = false,
+): Promise<Blob> => {
+  let lastError: unknown
+
+  for (const cdnUrl of getWebWorkerEntrypointCdnUrls(evalVersion)) {
+    try {
+      const response = await globalThis.fetch(cdnUrl)
+      if (!response.ok) {
+        throw new Error(
+          `Failed to fetch webworker entrypoint from ${cdnUrl}: ${response.status} ${response.statusText}`,
+        )
+      }
+      return await response.blob()
+    } catch (error) {
+      lastError = error
+      if (verbose) {
+        console.warn(
+          `[Worker] Failed to fetch webworker entrypoint from ${cdnUrl}, trying next CDN fallback if available`,
+          error,
+        )
+      }
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("Failed to fetch webworker entrypoint from CDN fallbacks")
+}
+
 export const createCircuitWebWorker = async (
   configuration: Partial<WebWorkerConfiguration>,
 ): Promise<CircuitWebWorker> => {
@@ -53,9 +89,10 @@ export const createCircuitWebWorker = async (
     configuration.webWorkerBlobUrl ?? configuration.webWorkerUrl
 
   if (!workerBlobUrl) {
-    const cdnUrl = `https://cdn.jsdelivr.net/npm/@tscircuit/eval@${configuration.evalVersion ?? "latest"}/dist/webworker/entrypoint.js`
-
-    const workerBlob = await globalThis.fetch(cdnUrl).then((res) => res.blob())
+    const workerBlob = await fetchWebWorkerEntrypointBlobFromCdn(
+      configuration.evalVersion ?? "latest",
+      configuration.verbose,
+    )
     workerBlobUrl = URL.createObjectURL(workerBlob)
   }
 

--- a/tests/features/webworker-cdn-fallback.test.ts
+++ b/tests/features/webworker-cdn-fallback.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import {
+  fetchWebWorkerEntrypointBlobFromCdn,
+  getWebWorkerEntrypointCdnUrls,
+} from "lib/worker"
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe("webworker CDN fallback", () => {
+  test("uses jsdelivr first and falls back to unpkg when jsdelivr fails", async () => {
+    const requestedUrls: string[] = []
+    const fallbackBlob = new Blob(["export {}"], {
+      type: "application/javascript",
+    })
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = input.toString()
+      requestedUrls.push(url)
+
+      if (url.includes("cdn.jsdelivr.net")) {
+        return new Response("not found", {
+          status: 404,
+          statusText: "Not Found",
+        })
+      }
+
+      return new Response(fallbackBlob, { status: 200 })
+    }) as typeof fetch
+
+    const blob = await fetchWebWorkerEntrypointBlobFromCdn("1.2.3")
+
+    expect(await blob.text()).toBe("export {}")
+    expect(requestedUrls).toEqual(getWebWorkerEntrypointCdnUrls("1.2.3"))
+  })
+})


### PR DESCRIPTION
### Motivation
- Ensure loading the default webworker entrypoint is resilient by trying an alternate CDN when the primary jsDelivr URL fails or returns a non-OK response.

### Description
- Add `getWebWorkerEntrypointCdnUrls(evalVersion)` which returns the jsDelivr and `unpkg` entrypoint URLs for a given `eval` version in `lib/worker.ts`.
- Add `fetchWebWorkerEntrypointBlobFromCdn(evalVersion, verbose)` which iterates the CDN URLs, attempts to `fetch` each, logs warnings on failures, and returns the first successful `Blob` or throws the last error.
- Update `createCircuitWebWorker` to call `fetchWebWorkerEntrypointBlobFromCdn` when `webWorkerBlobUrl` is not provided so the worker is loaded from CDN fallbacks.
- Add a regression test `tests/features/webworker-cdn-fallback.test.ts` that simulates jsDelivr returning 404 and verifies a subsequent `unpkg` fetch is attempted and its blob is returned.

### Testing
- Ran `bun test tests/features/webworker-cdn-fallback.test.ts`, which passed (1 test, 1 pass).
- Ran `bun run format:check` (biome format) which reported no fixes needed.
- The new test verifies the requested URLs sequence matches `getWebWorkerEntrypointCdnUrls("1.2.3")` and that the returned blob content is correct.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a037ebefa5883278ccc4b5b2a63136f)