### PR TITLE
Override the platformConfig parts engine from the tscircuit.config.ts

### DIFF
--- a/lib/getPlatformConfig/getPlatformConfigForTscircuitConfig.ts
+++ b/lib/getPlatformConfig/getPlatformConfigForTscircuitConfig.ts
@@ -1,0 +1,52 @@
+import type { WebWorkerConfiguration } from "lib/shared/types"
+import type { PlatformConfig } from "@tscircuit/props"
+import { getPlatformConfig } from "./getPlatformConfig"
+
+interface TscircuitConfigWithPlatformConfig {
+  platformConfig?: Partial<PlatformConfig>
+  partsEngine?: PlatformConfig["partsEngine"]
+}
+
+export const getPlatformConfigForTscircuitConfig = (
+  webWorkerConfiguration: WebWorkerConfiguration,
+  config: TscircuitConfigWithPlatformConfig | null,
+): PlatformConfig | undefined => {
+  const configPlatform = config?.platformConfig
+    ? config.platformConfig
+    : config?.partsEngine
+      ? { partsEngine: config.partsEngine }
+      : undefined
+
+  if (!configPlatform) return undefined
+
+  const mergedConfigPlatform = {
+    ...webWorkerConfiguration.projectConfig,
+    ...configPlatform,
+  }
+
+  if (webWorkerConfiguration.platform) {
+    const mergedPlatform = {
+      ...webWorkerConfiguration.platform,
+      ...mergedConfigPlatform,
+    }
+
+    if (mergedPlatform.partsEngineDisabled) {
+      mergedPlatform.partsEngine = undefined
+    }
+
+    return mergedPlatform
+  }
+
+  const platform = {
+    ...getPlatformConfig(mergedConfigPlatform, {
+      easyEdaProxyConfig: webWorkerConfiguration.easyEdaProxyConfig,
+    }),
+    ...mergedConfigPlatform,
+  }
+
+  if (platform.partsEngineDisabled) {
+    platform.partsEngine = undefined
+  }
+
+  return platform
+}

--- a/lib/runner/CircuitRunner.ts
+++ b/lib/runner/CircuitRunner.ts
@@ -13,6 +13,8 @@ import { setupDefaultEntrypointIfNeeded } from "./setupDefaultEntrypointIfNeeded
 import { enhanceRootCircuitHasNoChildrenError } from "lib/utils/enhance-root-circuit-error"
 import Debug from "debug"
 import { setValueAtPath } from "lib/shared/obj-path"
+import { loadTscircuitConfig } from "./loadTscircuitConfig"
+import { getPlatformConfigForTscircuitConfig } from "lib/getPlatformConfig/getPlatformConfigForTscircuitConfig"
 
 const debug = Debug("tsci:eval:CircuitRunner")
 
@@ -60,19 +62,36 @@ export class CircuitRunner implements CircuitRunnerApi {
       entrypoint: opts.entrypoint,
     })
 
+    const normalizedFsMap = normalizeFsMap(opts.fsMap)
+    const tscircuitConfig = await loadTscircuitConfig(
+      normalizedFsMap,
+      this._circuitRunnerConfiguration,
+      {
+        debugNamespace: this._debugNamespace,
+      },
+    )
+    const platformFromTscircuitConfig = getPlatformConfigForTscircuitConfig(
+      this._circuitRunnerConfiguration,
+      tscircuitConfig,
+    )
+
     this._executionContext = createExecutionContext(
       this._circuitRunnerConfiguration,
       {
         name: opts.name,
-        platform: this._circuitRunnerConfiguration.platform,
-        projectConfig: this._circuitRunnerConfiguration.projectConfig,
+        platform:
+          platformFromTscircuitConfig ??
+          this._circuitRunnerConfiguration.platform,
+        projectConfig: platformFromTscircuitConfig
+          ? undefined
+          : this._circuitRunnerConfiguration.projectConfig,
         debugNamespace: this._debugNamespace,
       },
     )
     this._bindEventListeners(this._executionContext.circuit)
 
     this._executionContext.entrypoint = opts.entrypoint!
-    this._executionContext.fsMap = normalizeFsMap(opts.fsMap)
+    this._executionContext.fsMap = normalizedFsMap
     this._executionContext.tsConfig = getTsConfig(this._executionContext.fsMap)
     if (!this._executionContext.fsMap[opts.entrypoint!]) {
       throw new Error(`Entrypoint "${opts.entrypoint}" not found`)

--- a/lib/runner/loadTscircuitConfig.ts
+++ b/lib/runner/loadTscircuitConfig.ts
@@ -1,0 +1,38 @@
+import type { PlatformConfig } from "@tscircuit/props"
+import { createExecutionContext, importEvalPath } from "lib/eval"
+import type { WebWorkerConfiguration } from "lib/shared/types"
+import { getTsConfig } from "./tsconfigPaths"
+
+const TSCIRCUIT_CONFIG_PATHS = ["tscircuit.config.ts", "tscircuit.config.js"]
+
+interface LoadedTscircuitConfig {
+  platformConfig?: Partial<PlatformConfig>
+  partsEngine?: PlatformConfig["partsEngine"]
+  [key: string]: any
+}
+
+export const loadTscircuitConfig = async (
+  fsMap: Record<string, string>,
+  webWorkerConfiguration: WebWorkerConfiguration,
+  opts: {
+    debugNamespace?: string
+  } = {},
+): Promise<LoadedTscircuitConfig | null> => {
+  const configPath = TSCIRCUIT_CONFIG_PATHS.find((path) => path in fsMap)
+  if (!configPath) return null
+
+  const ctx = createExecutionContext(webWorkerConfiguration, {
+    platform: webWorkerConfiguration.platform,
+    projectConfig: webWorkerConfiguration.projectConfig,
+    debugNamespace: opts.debugNamespace,
+  })
+  ctx.entrypoint = configPath
+  ctx.fsMap = fsMap
+  ctx.tsConfig = getTsConfig(fsMap)
+  ;(globalThis as any).__tscircuit_circuit = ctx.circuit
+
+  await importEvalPath(`./${configPath}`, ctx)
+
+  const moduleExports = ctx.preSuppliedImports[configPath]
+  return moduleExports?.default ?? moduleExports ?? null
+}

--- a/lib/runner/setupDefaultEntrypointIfNeeded.ts
+++ b/lib/runner/setupDefaultEntrypointIfNeeded.ts
@@ -16,10 +16,6 @@ export const setupDefaultEntrypointIfNeeded = (opts: {
       opts.mainComponentPath = "index.tsx"
     } else if ("index.ts" in opts.fsMap) {
       opts.mainComponentPath = "index.ts"
-    } else if (
-      Object.keys(opts.fsMap).filter((k) => k.endsWith(".tsx")).length === 1
-    ) {
-      opts.mainComponentPath = Object.keys(opts.fsMap)[0]
     } else if ("tscircuit.config.json" in opts.fsMap) {
       const configContent = opts.fsMap["tscircuit.config.json"]
       try {
@@ -30,6 +26,10 @@ export const setupDefaultEntrypointIfNeeded = (opts: {
       } catch (e) {
         console.warn("Failed to parse tscircuit.config.json:", e)
       }
+    } else if (
+      Object.keys(opts.fsMap).filter((k) => k.endsWith(".tsx")).length === 1
+    ) {
+      opts.mainComponentPath = Object.keys(opts.fsMap)[0]
     } else {
       throw new Error(
         "Either entrypoint or mainComponentPath must be provided (no index file, could not infer entrypoint)",

--- a/tests/features/parts-engine-platformConfig.test.ts
+++ b/tests/features/parts-engine-platformConfig.test.ts
@@ -1,0 +1,62 @@
+import { CircuitRunner, getPlatformConfig } from "lib/index"
+import { test, expect } from "bun:test"
+import type { SourceComponentBase } from "circuit-json"
+
+test("parts engine can be overridden via platform config", async () => {
+  const runner = new CircuitRunner()
+
+  await runner.executeWithFsMap({
+    fsMap: {
+      "example.tsx": `
+			circuit.add(
+                <board width="10mm" height="10mm">
+                    <resistor name="R1" resistance="1k" 
+                        footprint="ti:0402"
+                    />
+                </board>
+			)
+			`,
+      "tscircuit.config.json": `
+            {
+                "mainEntrypoint": "example.tsx",
+                "prebuildCommand": "bun test"
+            }
+        `,
+      "tscircuit.config.ts": `
+            export default {
+                platformConfig: {
+                    partsEngine: {
+                        findPart: async () => ({ ti: ["C987654"] }),
+                        fetchPartCircuitJson: async ({ supplierPartNumber }) => {
+                            return [{
+                                "type": "pcb_smtpad",
+                                "pcb_smtpad_id": "pcb_smtpad_23",
+                                "shape": "rect",
+                                "pcb_component_id": "pcb_component_0",
+                                "port_hints": ["23"],
+                                "x": 0,
+                                "y": 2,
+                                "width": 0.32,
+                                "height": 1.1,
+                                "layer": "top",
+                                "rotation": 0
+                            }]
+                        }
+                    }
+                }
+            }
+        `,
+    },
+  })
+
+  await runner.renderUntilSettled()
+
+  const circuitJson = await runner.getCircuitJson()
+  const sourceComponent = circuitJson.find(
+    (el) => el.type === "source_component" && el.name === "R1",
+  ) as SourceComponentBase
+
+  // @ts-expect-error - ti is a valid supplier name
+  expect(sourceComponent.supplier_part_numbers?.ti).toEqual(["C987654"])
+  await runner.kill()
+})

--- a/webworker/entrypoint.ts
+++ b/webworker/entrypoint.ts
@@ -17,6 +17,8 @@ import { enhanceRootCircuitHasNoChildrenError } from "lib/utils/enhance-root-cir
 import { setupFetchProxy } from "./fetchProxy"
 import { setValueAtPath } from "lib/shared/obj-path"
 import manifoldWasmUrl from "manifold-3d/manifold.wasm"
+import { loadTscircuitConfig } from "lib/runner/loadTscircuitConfig"
+import { getPlatformConfigForTscircuitConfig } from "lib/getPlatformConfig/getPlatformConfigForTscircuitConfig"
 
 globalThis.React = React
 setupFetchProxy()
@@ -157,15 +159,31 @@ const webWorkerApi = {
 
     let entrypoint = opts.entrypoint!
 
+    const normalizedFsMap = normalizeFsMap(opts.fsMap)
+    const tscircuitConfig = await loadTscircuitConfig(
+      normalizedFsMap,
+      circuitRunnerConfiguration,
+      {
+        debugNamespace,
+      },
+    )
+    const platformFromTscircuitConfig = getPlatformConfigForTscircuitConfig(
+      circuitRunnerConfiguration,
+      tscircuitConfig,
+    )
+
     executionContext = createExecutionContext(circuitRunnerConfiguration, {
       name: opts.name,
-      platform: circuitRunnerConfiguration.platform,
-      projectConfig: circuitRunnerConfiguration.projectConfig,
+      platform:
+        platformFromTscircuitConfig ?? circuitRunnerConfiguration.platform,
+      projectConfig: platformFromTscircuitConfig
+        ? undefined
+        : circuitRunnerConfiguration.projectConfig,
       debugNamespace,
     })
     bindEventListeners(executionContext.circuit)
     executionContext.entrypoint = entrypoint
-    executionContext.fsMap = normalizeFsMap(opts.fsMap)
+    executionContext.fsMap = normalizedFsMap
     executionContext.tsConfig = getTsConfig(executionContext.fsMap)
     if (!executionContext.fsMap[entrypoint]) {
       throw new Error(`Entrypoint "${opts.entrypoint}" not found`)


### PR DESCRIPTION
What could be a more appropriate name than `getPlatformConfigForTscircuitConfig`? @seveibar 