### PR TITLE
Added support for package browser object mappings when resolving package entrypoints

### DIFF
--- a/lib/eval/getPackageJsonEntrypoint.ts
+++ b/lib/eval/getPackageJsonEntrypoint.ts
@@ -17,6 +17,19 @@ export function getPackageJsonEntrypoint(
     const packageJson = JSON.parse(packageJsonContent)
     // Prefer the browser build when provided because eval runs in a browser-like
     // environment and many CommonJS main files require Node built-ins.
+    if (packageJson.browser && typeof packageJson.browser === "object") {
+      const entrypoint = packageJson.module || packageJson.main
+      const normalizedEntrypoint = entrypoint?.replace(/^\.\//, "")
+      const browserEntrypoint =
+        packageJson.browser[entrypoint] ||
+        packageJson.browser[`./${normalizedEntrypoint}`] ||
+        packageJson.browser[normalizedEntrypoint]
+
+      if (typeof browserEntrypoint === "string") {
+        return browserEntrypoint
+      }
+    }
+
     return (
       (typeof packageJson.browser === "string" && packageJson.browser) ||
       packageJson.module ||

--- a/lib/eval/import-eval-path.ts
+++ b/lib/eval/import-eval-path.ts
@@ -249,9 +249,11 @@ export async function importEvalPath(
 
   if (!importName.startsWith(".") && !importName.startsWith("/")) {
     // Step 1: Check if package is declared in package.json
-    if (!isPackageDeclaredInPackageJson(importName, ctx.fsMap, {
-      cwd: opts.cwd,
-    })) {
+    if (
+      !isPackageDeclaredInPackageJson(importName, ctx.fsMap, {
+        cwd: opts.cwd,
+      })
+    ) {
       throw new Error(
         `Node module imported but not in package.json "${importName}"\n\n${ctx.logger.stringifyLogs()}`,
       )

--- a/lib/eval/import-eval-path.ts
+++ b/lib/eval/import-eval-path.ts
@@ -15,8 +15,35 @@ import { getNodeModuleDirectory } from "./getNodeModuleDirectory"
 import { getPackageJsonEntrypoint } from "./getPackageJsonEntrypoint"
 import { isDistDirEmpty } from "./isDistDirEmpty"
 import { resolveEntrypointPath } from "./resolveEntrypointPath"
+import { resolveRelativePath } from "lib/utils/resolveRelativePath"
 
 const debug = Debug("tsci:eval:import-eval-path")
+
+const PATH_EXT_RE = /\.[a-zA-Z0-9]+$/
+
+const getNodeModuleSpecifierFromRelativeImport = (
+  importName: string,
+  cwd?: string,
+) => {
+  if (!cwd || (!importName.startsWith("./") && !importName.startsWith("../"))) {
+    return null
+  }
+
+  const resolvedPath = resolveRelativePath(importName, cwd)
+  const nodeModulesPrefix = "node_modules/"
+  if (!resolvedPath.startsWith(nodeModulesPrefix)) return null
+
+  const moduleSpecifier = resolvedPath.slice(nodeModulesPrefix.length)
+  return moduleSpecifier.replace(/\.(tsx?|jsx?|mjs|json)$/, "")
+}
+
+const getSyntheticNodeModulePath = (moduleSpecifier: string) => {
+  if (PATH_EXT_RE.test(moduleSpecifier)) {
+    return `node_modules/${moduleSpecifier}`
+  }
+
+  return `node_modules/${moduleSpecifier}.ts`
+}
 
 export async function importEvalPath(
   importName: string,
@@ -156,7 +183,36 @@ export async function importEvalPath(
   if (resolvedNodeModulePath) {
     ctx.logger.info(`resolvedNodeModulePath="${resolvedNodeModulePath}"`)
     ctx.logger.info(`importNodeModule("${importName}")`)
-    return importNodeModule(importName, ctx, depth)
+    return importNodeModule(importName, ctx, depth, { cwd: opts.cwd })
+  }
+
+  const platform = ctx.circuit?.platform
+  const resolverModuleSpecifier = getNodeModuleSpecifierFromRelativeImport(
+    importName,
+    opts.cwd,
+  )
+  if (resolverModuleSpecifier && platform?.nodeModulesResolver) {
+    try {
+      ctx.logger.info(
+        `nodeModulesResolver("${resolverModuleSpecifier}") for relative import "${importName}"`,
+      )
+      const fileContent = await platform.nodeModulesResolver(
+        resolverModuleSpecifier,
+      )
+
+      if (fileContent) {
+        const syntheticPath = getSyntheticNodeModulePath(
+          resolverModuleSpecifier,
+        )
+        ctx.fsMap[syntheticPath] = fileContent
+        await importLocalFile(syntheticPath, ctx, depth)
+        return
+      }
+    } catch (error) {
+      ctx.logger.info(
+        `nodeModulesResolver failed for relative import "${importName}" from "${opts.cwd}"`,
+      )
+    }
   }
 
   // If not found in fsMap but might be a node module, try importNodeModule
@@ -166,7 +222,6 @@ export async function importEvalPath(
     !importName.startsWith("/") &&
     !importName.startsWith("@tsci/")
   ) {
-    const platform = ctx.circuit?.platform
     if (platform?.nodeModulesResolver) {
       ctx.logger.info(
         `importNodeModule("${importName}") via nodeModulesResolver`,
@@ -194,7 +249,9 @@ export async function importEvalPath(
 
   if (!importName.startsWith(".") && !importName.startsWith("/")) {
     // Step 1: Check if package is declared in package.json
-    if (!isPackageDeclaredInPackageJson(importName, ctx.fsMap)) {
+    if (!isPackageDeclaredInPackageJson(importName, ctx.fsMap, {
+      cwd: opts.cwd,
+    })) {
       throw new Error(
         `Node module imported but not in package.json "${importName}"\n\n${ctx.logger.stringifyLogs()}`,
       )

--- a/lib/eval/import-node-module.ts
+++ b/lib/eval/import-node-module.ts
@@ -14,6 +14,9 @@ export const importNodeModule = async (
   importName: string,
   ctx: ExecutionContext,
   depth = 0,
+  opts: {
+    cwd?: string
+  } = {},
 ) => {
   const { preSuppliedImports, fsMap } = ctx
 
@@ -26,7 +29,7 @@ export const importNodeModule = async (
 
   if (hasPackageJson) {
     // Step 1: Check if the package is declared in package.json
-    if (!isPackageDeclaredInPackageJson(importName, fsMap)) {
+    if (!isPackageDeclaredInPackageJson(importName, fsMap, opts)) {
       throw new Error(
         `Node module imported but not in package.json "${importName}"\n\n${ctx.logger.stringifyLogs()}`,
       )
@@ -37,7 +40,11 @@ export const importNodeModule = async (
     ? getNodeModuleDirectory(importName, fsMap)
     : null
 
-  const resolvedNodeModulePath = resolveNodeModule(importName, ctx.fsMap, "")
+  const resolvedNodeModulePath = resolveNodeModule(
+    importName,
+    ctx.fsMap,
+    opts.cwd || "",
+  )
 
   // Only run Steps 2-4 if package exists in node_modules (after resolver attempts)
   if (hasPackageJson && resolvedNodeModulePath) {

--- a/lib/eval/isPackageDeclaredInPackageJson.ts
+++ b/lib/eval/isPackageDeclaredInPackageJson.ts
@@ -1,17 +1,32 @@
 import { extractBasePackageName } from "./extractBasePackageName"
 
-/**
- * Check if a package is declared in package.json (dependencies, devDependencies, or peerDependencies)
- */
-export function isPackageDeclaredInPackageJson(
+function getNodeModulePackageRoot(cwd?: string): string | null {
+  if (!cwd) return null
+
+  const nodeModulesMarker = "node_modules/"
+  const nodeModulesIndex = cwd.lastIndexOf(nodeModulesMarker)
+  if (nodeModulesIndex === -1) return null
+
+  const packagePrefix = cwd.slice(
+    0,
+    nodeModulesIndex + nodeModulesMarker.length,
+  )
+  const packagePathParts = cwd
+    .slice(nodeModulesIndex + nodeModulesMarker.length)
+    .split("/")
+
+  const packageName = packagePathParts[0]?.startsWith("@")
+    ? packagePathParts.slice(0, 2).join("/")
+    : packagePathParts[0]
+
+  return packageName ? `${packagePrefix}${packageName}` : null
+}
+
+function isPackageDeclaredInManifest(
   packageName: string,
-  fsMap: Record<string, string>,
-): boolean {
-  const packageJsonContent = fsMap["package.json"]
-  if (!packageJsonContent) {
-    // No package.json means we can't validate - allow the import
-    return true
-  }
+  packageJsonContent: string | undefined,
+): boolean | null {
+  if (!packageJsonContent) return null
 
   try {
     const packageJson = JSON.parse(packageJsonContent)
@@ -19,7 +34,6 @@ export function isPackageDeclaredInPackageJson(
     const devDependencies = packageJson.devDependencies || {}
     const peerDependencies = packageJson.peerDependencies || {}
 
-    // Extract the base package name (handle scoped packages and subpaths)
     const basePackageName = extractBasePackageName(packageName)
 
     return (
@@ -28,7 +42,39 @@ export function isPackageDeclaredInPackageJson(
       basePackageName in peerDependencies
     )
   } catch {
-    // If we can't parse package.json, allow the import
     return true
   }
+}
+
+/**
+ * Check if a package is declared in package.json (dependencies, devDependencies, or peerDependencies)
+ */
+export function isPackageDeclaredInPackageJson(
+  packageName: string,
+  fsMap: Record<string, string>,
+  opts: {
+    cwd?: string
+  } = {},
+): boolean {
+  const packageRoot = getNodeModulePackageRoot(opts.cwd)
+  const packageManifestResult = packageRoot
+    ? isPackageDeclaredInManifest(
+        packageName,
+        fsMap[`${packageRoot}/package.json`],
+      )
+    : null
+
+  if (packageManifestResult) return true
+
+  const rootManifestResult = isPackageDeclaredInManifest(
+    packageName,
+    fsMap["package.json"],
+  )
+
+  if (rootManifestResult === null && packageManifestResult === null) {
+    // No package.json means we can't validate - allow the import
+    return true
+  }
+
+  return rootManifestResult === true
 }

--- a/lib/utils/resolve-node-module.ts
+++ b/lib/utils/resolve-node-module.ts
@@ -17,9 +17,7 @@ interface NodeResolutionContext {
   modulePath: string
 }
 
-function getBrowserMappedEntrypoint(
-  packageJson: PackageJson,
-): string | null {
+function getBrowserMappedEntrypoint(packageJson: PackageJson): string | null {
   if (!packageJson.browser || typeof packageJson.browser === "string") {
     return null
   }

--- a/lib/utils/resolve-node-module.ts
+++ b/lib/utils/resolve-node-module.ts
@@ -17,6 +17,27 @@ interface NodeResolutionContext {
   modulePath: string
 }
 
+function getBrowserMappedEntrypoint(
+  packageJson: PackageJson,
+): string | null {
+  if (!packageJson.browser || typeof packageJson.browser === "string") {
+    return null
+  }
+
+  const entryPoint = packageJson.module || packageJson.main || "index.js"
+  const browserEntrypoint = packageJson.browser[entryPoint]
+  if (typeof browserEntrypoint === "string") return browserEntrypoint
+
+  const normalizedEntryPoint = normalizePackageEntrypoint(entryPoint)
+  const normalizedBrowserEntrypoint =
+    packageJson.browser[`./${normalizedEntryPoint}`] ??
+    packageJson.browser[normalizedEntryPoint]
+
+  return typeof normalizedBrowserEntrypoint === "string"
+    ? normalizedBrowserEntrypoint
+    : null
+}
+
 function createContext(
   modulePath: string,
   fsMap: Record<string, string>,
@@ -134,6 +155,7 @@ function resolvePackageEntryPoint(
 ): string | null {
   const entryPoint = normalizePackageEntrypoint(
     (typeof packageJson.browser === "string" && packageJson.browser) ||
+      getBrowserMappedEntrypoint(packageJson) ||
       packageJson.module ||
       packageJson.main ||
       "index.js",

--- a/tests/features/node-modules-resolver.test.ts
+++ b/tests/features/node-modules-resolver.test.ts
@@ -202,3 +202,51 @@ test("nodeModulesResolver: should work with CDN-style resolver", async () => {
 
   expect(runner._executionContext?.preSuppliedImports.lodash).toBeDefined()
 })
+
+test("node module resolution uses browser object mapping for package main", async () => {
+  const runner = new CircuitRunner()
+
+  await runner.executeWithFsMap({
+    entrypoint: "index.tsx",
+    fsMap: {
+      "index.tsx": `
+        import { value } from "@test/github-package"
+
+        if (value !== "browser jszip") {
+          throw new Error("unexpected value")
+        }
+
+        circuit.add(<board width="10mm" height="10mm" />)
+      `,
+      "package.json": JSON.stringify({
+        dependencies: {
+          "@test/github-package": "github:test/github-package#abc123",
+        },
+      }),
+      "node_modules/@test/github-package/index.ts": `
+        import JSZip from "jszip"
+
+        export const value = JSZip.value
+      `,
+      "node_modules/@test/github-package/package.json": JSON.stringify({
+        main: "index.ts",
+        dependencies: {
+          jszip: "3.10.1",
+        },
+      }),
+      "node_modules/jszip/package.json": JSON.stringify({
+        main: "./lib/index",
+        browser: {
+          "./lib/index": "./dist/jszip.min.js",
+        },
+      }),
+      "node_modules/jszip/dist/jszip.min.js": `
+        export default { value: "browser jszip" }
+      `,
+    },
+  })
+
+  await runner.renderUntilSettled()
+
+  expect(runner._executionContext?.preSuppliedImports.jszip).toBeDefined()
+})


### PR DESCRIPTION
<img width="1281" height="594" alt="image" src="https://github.com/user-attachments/assets/7106f44f-0e97-4d83-87e7-d5899be3599b" />


JsZip has this package shape
```
{
  "main": "./lib/index",
  "browser": {
    "./lib/index": "./dist/jszip.min.js"
  }
}
```