### PR TITLE
Improve static asset placeholder errors in eval

### DIFF
--- a/lib/eval/eval-compiled-js.ts
+++ b/lib/eval/eval-compiled-js.ts
@@ -1,4 +1,5 @@
 import { resolveFilePath } from "lib/runner/resolveFilePath"
+import { enhanceStaticAssetSentinelError } from "lib/utils/enhance-static-asset-error"
 import { resolveNodeModule } from "lib/utils/resolve-node-module"
 
 export function evalCompiledJs(
@@ -105,5 +106,9 @@ export function evalCompiledJs(
   var circuit = globalThis.__tscircuit_circuit;
   ${compiledCode};
   return module;`.trim()
-  return Function(functionBody).call(globalThis)
+  try {
+    return Function(functionBody).call(globalThis)
+  } catch (error) {
+    throw enhanceStaticAssetSentinelError(error, { cwd })
+  }
 }

--- a/lib/eval/import-local-file.ts
+++ b/lib/eval/import-local-file.ts
@@ -1,14 +1,15 @@
+import type { PlatformConfig } from "@tscircuit/props"
+import Debug from "debug"
 import { resolveFilePathOrThrow } from "lib/runner/resolveFilePath"
+import { isStaticAssetPath } from "lib/shared/static-asset-extensions"
+import { transformWithSucrase } from "lib/transpile/transform-with-sucrase"
 import { dirname } from "lib/utils/dirname"
+import { enhanceStaticAssetSentinelError } from "lib/utils/enhance-static-asset-error"
 import { getImportsFromCode } from "lib/utils/get-imports-from-code"
 import { getTypeExportsFromCode } from "lib/utils/get-type-exports-from-code"
 import { evalCompiledJs } from "./eval-compiled-js"
 import type { ExecutionContext } from "./execution-context"
 import { importEvalPath } from "./import-eval-path"
-import Debug from "debug"
-import { isStaticAssetPath } from "lib/shared/static-asset-extensions"
-import { transformWithSucrase } from "lib/transpile/transform-with-sucrase"
-import type { PlatformConfig } from "@tscircuit/props"
 
 const debug = Debug("tsci:eval:import-local-file")
 
@@ -160,8 +161,19 @@ export const importLocalFile = async (
         }
         preSuppliedImports[fsPath] = moduleExports
       } catch (error: any) {
+        const enhancedError = enhanceStaticAssetSentinelError(error, {
+          importName,
+          cwd: dirname(fsPath),
+        })
         throw new Error(
-          `Eval compiled js error for "${importName}": ${error.message}`,
+          `Eval compiled js error for "${importName}": ${
+            enhancedError instanceof Error
+              ? enhancedError.message
+              : String(enhancedError)
+          }`,
+          {
+            cause: enhancedError instanceof Error ? enhancedError : error,
+          },
         )
       }
     } else if (fsPath.endsWith(".js") || fsPath.endsWith(".mjs")) {
@@ -177,11 +189,28 @@ export const importLocalFile = async (
       }
 
       // Then transform and evaluate
-      preSuppliedImports[fsPath] = evalCompiledJs(
-        transformWithSucrase(fileContent, fsPath),
-        preSuppliedImports,
-        dirname(fsPath),
-      ).exports
+      try {
+        preSuppliedImports[fsPath] = evalCompiledJs(
+          transformWithSucrase(fileContent, fsPath),
+          preSuppliedImports,
+          dirname(fsPath),
+        ).exports
+      } catch (error: any) {
+        const enhancedError = enhanceStaticAssetSentinelError(error, {
+          importName,
+          cwd: dirname(fsPath),
+        })
+        throw new Error(
+          `Eval compiled js error for "${importName}": ${
+            enhancedError instanceof Error
+              ? enhancedError.message
+              : String(enhancedError)
+          }`,
+          {
+            cause: enhancedError instanceof Error ? enhancedError : error,
+          },
+        )
+      }
     } else {
       throw new Error(
         `Unsupported file extension "${fsPath.split(".").pop()}" for "${fsPath}"`,

--- a/lib/eval/import-npm-package-from-cdn.ts
+++ b/lib/eval/import-npm-package-from-cdn.ts
@@ -1,11 +1,12 @@
+import Debug from "debug"
+import { transformWithSucrase } from "lib/transpile/transform-with-sucrase"
+import { dirname } from "lib/utils/dirname"
+import { enhanceStaticAssetSentinelError } from "lib/utils/enhance-static-asset-error"
+import { getImportsFromCode } from "lib/utils/get-imports-from-code"
+import { getJscdnPackageUrl } from "lib/utils/npm-cdn-urls"
 import { evalCompiledJs } from "./eval-compiled-js"
 import type { ExecutionContext } from "./execution-context"
-import { dirname } from "lib/utils/dirname"
-import Debug from "debug"
-import { getImportsFromCode } from "lib/utils/get-imports-from-code"
 import { importEvalPath } from "./import-eval-path"
-import { transformWithSucrase } from "lib/transpile/transform-with-sucrase"
-import { getJscdnPackageUrl } from "lib/utils/npm-cdn-urls"
 
 const debug = Debug("tsci:eval:import-npm-package")
 
@@ -75,7 +76,9 @@ export async function importNpmPackageFromCdn(
       preSuppliedImports[response.url] = exports
       return
     } catch (error) {
-      lastCdnError = error
+      lastCdnError = enhanceStaticAssetSentinelError(error, {
+        importName,
+      })
     }
   }
 

--- a/lib/utils/enhance-static-asset-error.ts
+++ b/lib/utils/enhance-static-asset-error.ts
@@ -1,0 +1,39 @@
+const STATIC_ASSET_SENTINEL = "__STATIC_ASSET__"
+
+const getErrorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : String(error)
+
+export const isStaticAssetSentinelError = (error: unknown) =>
+  getErrorMessage(error).includes(`${STATIC_ASSET_SENTINEL} is not defined`) ||
+  getErrorMessage(error).includes(
+    `Static asset placeholder "${STATIC_ASSET_SENTINEL}" was evaluated as JavaScript`,
+  )
+
+export const enhanceStaticAssetSentinelError = (
+  error: unknown,
+  opts: {
+    importName?: string
+    cwd?: string
+  } = {},
+) => {
+  if (!isStaticAssetSentinelError(error)) {
+    return error
+  }
+
+  const importContext = opts.importName
+    ? ` while importing "${opts.importName}"`
+    : ""
+  const cwdContext = opts.cwd ? ` from "${opts.cwd}"` : ""
+  const message = `Static asset placeholder ${JSON.stringify(
+    STATIC_ASSET_SENTINEL,
+  )} was evaluated as JavaScript${importContext}${cwdContext}. This usually means a browser fsMap or package resolver supplied a static asset placeholder as module source instead of a real file URL/content. Provide the asset contents, a blob URL, or configure platform.projectBaseUrl/staticFileLoaderMap for that asset.`
+
+  const cause =
+    error instanceof Error && error.cause instanceof Error
+      ? error.cause
+      : error instanceof Error
+        ? error
+        : undefined
+
+  return new Error(message, { cause })
+}

--- a/tests/features/static-asset-placeholder-error.test.ts
+++ b/tests/features/static-asset-placeholder-error.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test"
+import { CircuitRunner } from "lib/runner/CircuitRunner"
+
+test("reports a helpful error when a static asset placeholder is evaluated as JavaScript from tscircuit.config.ts", async () => {
+  const runner = new CircuitRunner()
+
+  try {
+    await runner.executeWithFsMap({
+      entrypoint: "index.tsx",
+      fsMap: {
+        "package.json": JSON.stringify({
+          dependencies: {
+            "bad-static-package": "1.0.0",
+          },
+        }),
+        "tscircuit.config.ts": `
+          import config from "bad-static-package"
+
+          export default {
+            platformConfig: config,
+          }
+        `,
+        "index.tsx": `
+          circuit.add(<board width="10mm" height="10mm" />)
+        `,
+        "node_modules/bad-static-package/package.json": JSON.stringify({
+          main: "index.js",
+        }),
+        "node_modules/bad-static-package/index.js": `
+          export default __STATIC_ASSET__
+        `,
+      },
+    })
+    throw new Error("Expected executeWithFsMap to fail")
+  } catch (error: any) {
+    expect(error.message).toContain(
+      'Static asset placeholder "__STATIC_ASSET__" was evaluated as JavaScript',
+    )
+    expect(error.message).toContain(
+      'while importing "node_modules/bad-static-package/index.js"',
+    )
+    expect(error.message).toContain(
+      "Provide the asset contents, a blob URL, or configure platform.projectBaseUrl/staticFileLoaderMap",
+    )
+  }
+})


### PR DESCRIPTION
## Summary
- Detect `__STATIC_ASSET__` reference errors during eval and rewrite them into a clearer static-asset configuration error.
- Preserve importer context so failures point at the module that evaluated the placeholder.
- Add a regression test covering the browser/config loading path that reproduces the issue.

## Testing
- `bunx tsc --noEmit`
- `bunx @biomejs/biome@1.9.4 check ...`
- `bun test tests/features/static-asset-placeholder-error.test.ts`
- `bun test tests/features/static-file-loader-map.test.tsx`
- `bun test tests/features/static-file-imports/static-file-import.test.ts`