### PR TITLE
 Bundle scoped ngspice engine for browser simulations

### DIFF
--- a/lib/getPlatformConfig/getPlatformConfig.ts
+++ b/lib/getPlatformConfig/getPlatformConfig.ts
@@ -1,4 +1,5 @@
 import type { PlatformConfig, SpiceEngine, PartsEngine } from "@tscircuit/props"
+import createNgspiceSpiceEngineDefault from "@tscircuit/ngspice-spice-engine"
 import {
   JlcPcbPartsEngine,
   jlcPartsEngine,
@@ -22,6 +23,7 @@ type PlatformCreateAutorouter =
 type PlatformStaticFileLoaderMap = NonNullable<
   PlatformConfig["staticFileLoaderMap"]
 >
+type CreateNgspiceSpiceEngine = typeof createNgspiceSpiceEngineDefault
 
 const toJlcpcbSupplierPartNumber = (partNumber: string) => {
   if (/^\d+$/.test(partNumber)) {
@@ -110,19 +112,18 @@ export const getPlatformConfig = (
         simulate: async (spice: string) => {
           if (!ngspiceEngineCache) {
             const createNgspiceSpiceEngine =
-              await dynamicallyLoadDependencyWithCdnBackup(
+              (await dynamicallyLoadDependencyWithCdnBackup(
                 "@tscircuit/ngspice-spice-engine",
+                createNgspiceSpiceEngineDefault,
               ).catch((error) => {
                 throw new Error(
                   "Could not load ngspice engine from local node_modules or CDN fallback.",
                   { cause: error },
                 )
-              })
+              })) as CreateNgspiceSpiceEngine
 
             if (createNgspiceSpiceEngine) {
-              ngspiceEngineCache = await createNgspiceSpiceEngine({
-                pspiceCompatibility: true,
-              })
+              ngspiceEngineCache = await createNgspiceSpiceEngine()
             }
           }
 

--- a/lib/utils/dynamically-load-dependency-with-cdn-backup.ts
+++ b/lib/utils/dynamically-load-dependency-with-cdn-backup.ts
@@ -14,9 +14,14 @@ export const transformJsDelivrImports = (code: string): string => {
     )
 }
 
-export const dynamicallyLoadDependencyWithCdnBackup = async (
+export const dynamicallyLoadDependencyWithCdnBackup = async <T = any>(
   packageName: string,
-): Promise<any> => {
+  localModule?: T,
+): Promise<T> => {
+  if (localModule) {
+    return localModule
+  }
+
   try {
     // First, try to import using Node.js resolution
     const module = await import(packageName)

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "concurrently": "^9.1.2",
     "connectivity-map": "^1.0.0",
     "debug": "^4.3.6",
-    "eecircuit-engine": "^1.5.6",
     "flatbush": "^4.5.0",
     "graphics-debug": "^0.0.95",
     "howfat": "^0.3.8",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@tscircuit/math-utils": "^0.0.36",
     "@tscircuit/miniflex": "^0.0.4",
     "@tscircuit/mm": "^0.0.9",
-    "@tscircuit/ngspice-spice-engine": "^0.0.10",
+    "@tscircuit/ngspice-spice-engine": "^0.0.12",
     "@tscircuit/parts-engine": "^0.0.21",
     "@tscircuit/props": "^0.0.546",
     "@tscircuit/schematic-autolayout": "^0.0.6",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@tscircuit/common": "^0.0.20",
     "@tscircuit/copper-pour-solver": "^0.0.29",
     "@tscircuit/core": "^0.0.1322",
+    "@tscircuit/eecircuit-engine": "https://jscdn.tscircuit.com/@tscircuit/eecircuit-engine/1.7.2.tgz",
     "@tscircuit/footprinter": "^0.0.357",
     "@tscircuit/import-snippet": "^0.0.4",
     "@tscircuit/infer-cable-insertion-point": "^0.0.2",

--- a/tests/repros/eecircuit-engine-cdn-import.test.ts
+++ b/tests/repros/eecircuit-engine-cdn-import.test.ts
@@ -3,11 +3,11 @@ import { transformJsDelivrImports } from "lib/utils/dynamically-load-dependency-
 
 /**
  * This test reproduces the error:
- * "simulation_unknown_experiment_error:Error resolving module specifier '/npm/eecircuit-engine@1.5.6/+esm'"
+ * "simulation_unknown_experiment_error:Error resolving module specifier '/npm/@tscircuit/eecircuit-engine@1.7.2/+esm'"
  *
  * The issue occurs when:
  * 1. ngspice-spice-engine is loaded from jsdelivr CDN
- * 2. The CDN bundle contains: import("/npm/eecircuit-engine@1.5.6/+esm")
+ * 2. The CDN bundle contains: import("/npm/@tscircuit/eecircuit-engine@1.7.2/+esm")
  * 3. When loaded via blob URL, the browser resolves "/npm/..." relative to page origin
  *
  * This test verifies the CDN code contains the problematic import pattern
@@ -28,32 +28,31 @@ describe("eecircuit-engine CDN import issue", () => {
     const hasRelativeNpmImport = code.includes('import("/npm/')
     expect(hasRelativeNpmImport).toBe(true)
 
-    // Verify the specific eecircuit-engine import exists
-    const hasEecircuitImport = /import\s*\(\s*["']\/npm\/eecircuit-engine/.test(
-      code,
-    )
+    // Verify the specific @tscircuit/eecircuit-engine import exists
+    const hasEecircuitImport =
+      /import\s*\(\s*["']\/npm\/@tscircuit\/eecircuit-engine/.test(code)
     expect(hasEecircuitImport).toBe(true)
   })
 
   test("transformJsDelivrImports fixes the relative import", () => {
     const input =
-      'const{Simulation:t}=await import("/npm/eecircuit-engine@1.5.6/+esm")'
+      'const{Simulation:t}=await import("/npm/@tscircuit/eecircuit-engine@1.7.2/+esm")'
     const output = transformJsDelivrImports(input)
 
     expect(output).toBe(
-      'const{Simulation:t}=await import("https://cdn.jsdelivr.net/npm/eecircuit-engine@1.5.6/+esm")',
+      'const{Simulation:t}=await import("https://cdn.jsdelivr.net/npm/@tscircuit/eecircuit-engine@1.7.2/+esm")',
     )
     expect(output).not.toContain('"/npm/')
   })
 
   test("blob URL with untransformed /npm/ import fails with module resolution error", async () => {
     // This reproduces the actual error:
-    // "Cannot find module '/npm/eecircuit-engine@1.5.6/+esm'"
+    // "Cannot find module '/npm/@tscircuit/eecircuit-engine@1.7.2/+esm'"
     // which in browser manifests as:
-    // "Error resolving module specifier '/npm/eecircuit-engine@1.5.6/+esm'"
+    // "Error resolving module specifier '/npm/@tscircuit/eecircuit-engine@1.7.2/+esm'"
     const codeWithRelativeImport = `
       export default async function test() {
-        const { Simulation } = await import("/npm/eecircuit-engine@1.5.6/+esm");
+        const { Simulation } = await import("/npm/@tscircuit/eecircuit-engine@1.7.2/+esm");
         return Simulation;
       }
     `
@@ -75,7 +74,7 @@ describe("eecircuit-engine CDN import issue", () => {
       }
       expect(error).not.toBeNull()
       expect(error!.message).toMatch(
-        /Cannot find module.*\/npm\/eecircuit-engine/,
+        /Cannot find module.*\/npm\/@tscircuit\/eecircuit-engine/,
       )
     } finally {
       URL.revokeObjectURL(url)
@@ -86,7 +85,7 @@ describe("eecircuit-engine CDN import issue", () => {
     // After transformation, the import points to the full jsdelivr URL
     const codeWithRelativeImport = `
       export default async function test() {
-        const { Simulation } = await import("/npm/eecircuit-engine@1.5.6/+esm");
+        const { Simulation } = await import("/npm/@tscircuit/eecircuit-engine@1.7.2/+esm");
         return Simulation;
       }
     `
@@ -95,7 +94,7 @@ describe("eecircuit-engine CDN import issue", () => {
 
     // Verify the transformation happened
     expect(transformedCode).toContain(
-      "https://cdn.jsdelivr.net/npm/eecircuit-engine",
+      "https://cdn.jsdelivr.net/npm/@tscircuit/eecircuit-engine",
     )
     expect(transformedCode).not.toContain('"/npm/')
 
@@ -130,7 +129,7 @@ describe("eecircuit-engine CDN import issue", () => {
 
     // Verify the imports are now absolute
     expect(transformedCode).toContain(
-      "https://cdn.jsdelivr.net/npm/eecircuit-engine",
+      "https://cdn.jsdelivr.net/npm/@tscircuit/eecircuit-engine",
     )
   })
 })

--- a/tsup-webworker.config.ts
+++ b/tsup-webworker.config.ts
@@ -10,6 +10,8 @@ export default defineConfig({
   minify: false,
   noExternal: [
     "@tscircuit/core",
+    "@tscircuit/eecircuit-engine",
+    "@tscircuit/ngspice-spice-engine",
     "circuit-json",
     "@tscircuit/parts-engine",
     "sucrase",


### PR DESCRIPTION
 Replaces the old unscoped eecircuit-engine dependency with the scoped @tscircuit/
  eecircuit-engine tarball and updates @tscircuit/ngspice-spice-engine to ^0.0.12.

  Passes the local ngspice factory into the CDN fallback loader so browser builds can use
  the installed module instead of relying on broken scoped CDN +esm resolution, and removes
  the obsolete pspiceCompatibility option.

  Updates the repro test expectations for the scoped @tscircuit/eecircuit-engine import path
  and bundles both ngspice packages into the webworker build.
  
  fixes this issue:
  
<img width="1111" height="721" alt="image" src="https://github.com/user-attachments/assets/c5186d3f-715f-4009-8cf3-e438f804e38c" />

