### PR TITLE
Replaces the legacy kicad-component-converter footprint path with KicadFootprintToCircuitJsonConverter from kicad-to-circuit-json

### DIFF
--- a/lib/getPlatformConfig/getPlatformConfig.ts
+++ b/lib/getPlatformConfig/getPlatformConfig.ts
@@ -5,10 +5,12 @@ import {
   type EasyEdaProxyConfig,
 } from "@tscircuit/parts-engine"
 import { createKiCadRoutingToolsAutorouter } from "@tscircuit/krt-wasm"
-import { parseKicadModToCircuitJson } from "kicad-component-converter"
 import { dynamicallyLoadDependencyWithCdnBackup } from "../utils/dynamically-load-dependency-with-cdn-backup"
 import { extractCadModelFromCircuitJson } from "./extractCadModelFromCircuitJson"
-import { KicadToCircuitJsonConverter } from "kicad-to-circuit-json"
+import {
+  KicadFootprintToCircuitJsonConverter,
+  KicadToCircuitJsonConverter,
+} from "kicad-to-circuit-json"
 import type { AnyCircuitElement } from "circuit-json"
 import * as React from "react"
 
@@ -201,7 +203,10 @@ export const getPlatformConfig = (
       kicad_mod: {
         loadFromUrl: async (url: string) => {
           const kicadContent = await fetch(url).then((res) => res.text())
-          const kicadJson = await parseKicadModToCircuitJson(kicadContent)
+          const converter = new KicadFootprintToCircuitJsonConverter()
+          converter.addFile("footprint.kicad_mod", kicadContent)
+          converter.runUntilFinished()
+          const kicadJson = converter.getOutput()
           return {
             footprintCircuitJson: Array.isArray(kicadJson)
               ? kicadJson

--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "flatbush": "^4.5.0",
     "graphics-debug": "^0.0.95",
     "howfat": "^0.3.8",
-    "kicad-component-converter": "^0.1.30",
     "kicad-to-circuit-json": "^0.0.97",
     "kicadts": "^0.0.47",
     "live-server": "^1.2.2",


### PR DESCRIPTION
Replaces the legacy kicad-component-converter footprint path with KicadFootprintToCircuitJsonConverter from kicad-to-circuit-json.

Validation:
- bun run build:platform-config
- bun test --timeout 20000 tests/features/kicad-pcb-import.test.tsx
- bun test tests/features/static-file-imports/static-file-import.test.ts
