### PR TITLE
refactor: replaces `renderGLTFToPNGBufferFromGLBBuffer` with `renderGLTFToPNGFromGLB`  after poppygl GLB render API change

### DIFF
--- a/tests/features/kicad-footprint-library-map-tl3342-cadmodel.test.tsx
+++ b/tests/features/kicad-footprint-library-map-tl3342-cadmodel.test.tsx
@@ -7,7 +7,7 @@ import { CircuitRunner } from "lib/runner/CircuitRunner"
 import * as fs from "node:fs"
 import * as path from "node:path"
 import looksSame from "looks-same"
-import { renderGLTFToPNGBufferFromGLBBuffer } from "poppygl"
+import { renderGLTFToPNGFromGLB } from "poppygl"
 import tl3342FootprintCircuitJson from "tests/fixtures/assets/SW_SPST_TL3342.json"
 import { repoFileUrl } from "tests/fixtures/resourcePaths"
 
@@ -63,7 +63,7 @@ const renderCircuitJsonTo3dPng = async (
       ? [board.width / 2, (board.width + board.height) / 2, board.height / 2]
       : undefined
 
-  const png = await renderGLTFToPNGBufferFromGLBBuffer(
+  const png = await renderGLTFToPNGFromGLB(
     Buffer.from(glb as any),
     {
       width: 1024,


### PR DESCRIPTION
## Summary

This PR updates the TL3342 CAD model 3D snapshot test to use the current `poppygl` GLB rendering API.

It replaces `renderGLTFToPNGBufferFromGLBBuffer` with `renderGLTFToPNGFromGLB` while preserving the existing PNG buffer normalization used by the snapshot comparison path.

## Why

The TL3342 3D snapshot coverage depends on rendering a GLB produced from circuit JSON. Keeping this test aligned with the current `poppygl` GLB renderer entrypoint reduces API drift and avoids avoidable test regressions as the renderer evolves.

## Impact

- Keeps TL3342 CAD model snapshot coverage intact
- Aligns the test with the current `poppygl` GLB rendering API
- Reduces maintenance risk in the 3D snapshot pipeline

## Validation

Ran locally:

`bun test tests/features/kicad-footprint-library-map-tl3342-cadmodel.test.tsx`

Passed:

- `kicad footprint library map returns cadModel for TL3342 footprint`
- `kicad footprint library map renders TL3342 3d snapshot with cad model`
