### PR TITLE
fix(eval): treat .cjs node_modules entries as transpilable source

### DIFF
--- a/lib/eval/import-local-file.ts
+++ b/lib/eval/import-local-file.ts
@@ -165,8 +165,12 @@ export const importLocalFile = async (
           `Eval compiled js error for "${importName}": ${error.message}`,
         )
       }
-    } else if (fsPath.endsWith(".js") || fsPath.endsWith(".mjs")) {
-      // For .js/.mjs files, especially from node_modules, we need to extract and resolve imports first
+    } else if (
+      fsPath.endsWith(".js") ||
+      fsPath.endsWith(".mjs") ||
+      fsPath.endsWith(".cjs")
+    ) {
+      // For .js/.mjs/.cjs files, especially from node_modules, we need to extract and resolve imports first
       const importNames = getImportsFromCode(fileContent)
 
       for (const importName of importNames) {

--- a/tests/node-resolution/node-module-resolution-cjs-entry.test.tsx
+++ b/tests/node-resolution/node-module-resolution-cjs-entry.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test"
+import { runTscircuitCode } from "lib/runner"
+
+describe("node module resolution", () => {
+  test("resolves a dependency whose main entry is a .cjs CommonJS file", async () => {
+    const circuitJson = await runTscircuitCode(
+      {
+        "node_modules/cjs-package/package.json": JSON.stringify({
+          name: "cjs-package",
+          main: "dist/index.cjs",
+        }),
+        "node_modules/cjs-package/dist/index.cjs": `
+          module.exports = {
+            resistorName: "R5",
+            resistanceValue: "5k",
+          }
+        `,
+        "user-code.tsx": `
+          import { resistorName, resistanceValue } from "cjs-package"
+          export default () => (<resistor name={resistorName} resistance={resistanceValue} />)
+        `,
+      },
+      {
+        mainComponentPath: "user-code",
+      },
+    )
+    const resistor = circuitJson.find(
+      (element) => element.type === "source_component",
+    ) as any
+    expect(resistor).toBeDefined()
+    expect(resistor.resistance).toBe(5000)
+    expect(resistor.name).toBe("R5")
+  })
+})


### PR DESCRIPTION
## Problem

The local-file importer (`lib/eval/import-local-file.ts`) handles `.ts/.tsx`, `.js/.mjs`, `.json`, and static assets, but **throws `Unsupported file extension "cjs"`** for `.cjs`.

Dual-package npm modules commonly ship a CommonJS build as `dist/index.cjs` and set `"main": "dist/index.cjs"`. eval already transpiles `.js`/`.mjs` with sucrase (which handles CommonJS via the injected `module`/`exports`/`require`), so `.cjs` should be treated identically. As written, **any tscircuit project that imports a dependency whose resolved entry is `.cjs` fails to evaluate** (e.g. `jscad-planner`).

Note `tsci build` (Node) is unaffected — this manifests in the eval/browser path.

## Fix

Route `.cjs` through the same `.js`/`.mjs` sucrase path:

```ts
} else if (
  fsPath.endsWith(".js") ||
  fsPath.endsWith(".mjs") ||
  fsPath.endsWith(".cjs")
) {
```

## Test

Adds `tests/node-resolution/node-module-resolution-cjs-entry.test.tsx`, which resolves a dependency whose `main` is `dist/index.cjs` (CommonJS `module.exports`). Verified it **fails before** the dispatch change (`Unsupported file extension "cjs"`) and **passes after**.

## Risk

Negligible — `.cjs` goes through the exact same sucrase path as `.js`.

---

Draft: opening for review before merge. (`package.json` is intentionally excluded — local yalc artifacts only.)