### PR TITLE
Remove unused circuit-json-to-simple-3d dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "circuit-json-to-bpc": "^0.0.13",
     "circuit-json-to-connectivity-map": "^0.0.23",
     "circuit-json-to-gltf": "^0.0.105",
-    "circuit-json-to-simple-3d": "^0.0.9",
     "circuit-json-to-spice": "^0.0.40",
     "circuit-to-svg": "^0.0.371",
     "comlink": "^4.4.2",


### PR DESCRIPTION
## Summary

- Remove the unused `circuit-json-to-simple-3d` development dependency from `@tscircuit/eval`.
- Confirm that the package has no imports or source references in this repository.
- Keep existing 3D snapshot coverage, which uses `circuit-json-to-gltf` where applicable.

## Why

The dependency was inherited through historical core dependency synchronization, but it is not used by eval source code. `@tscircuit/core` no longer declares or uses it.

## Validation

- Searched repository source, tests, scripts, and configuration for references.
- Verified `package.json` remains valid.
- Confirmed the change is limited to removing the dependency declaration.