### PR TITLE
Improve TSX transform recovery and errors

### DIFF
--- a/lib/eval/import-local-file.ts
+++ b/lib/eval/import-local-file.ts
@@ -171,8 +171,8 @@ export const importLocalFile = async (
         }
       }
 
+      const transformedCode = transformWithSucrase(fileContent, fsPath)
       try {
-        const transformedCode = transformWithSucrase(fileContent, fsPath)
         debug("evalCompiledJs called with:", {
           code: transformedCode.slice(0, 100),
           dirname: dirname(fsPath),
@@ -193,9 +193,7 @@ export const importLocalFile = async (
         }
         preSuppliedImports[fsPath] = moduleExports
       } catch (error: any) {
-        throw new Error(
-          `Eval compiled js error for "${importName}": ${error.message}`,
-        )
+        throw new Error(`Error evaluating "${fsPath}": ${error.message}`)
       }
     } else if (fsPath.endsWith(".js") || fsPath.endsWith(".mjs")) {
       // For .js/.mjs files, especially from node_modules, we need to extract and resolve imports first

--- a/lib/transpile/transform-with-sucrase.ts
+++ b/lib/transpile/transform-with-sucrase.ts
@@ -1,4 +1,4 @@
-import { transform, type Transform as SucraseTransform } from "sucrase"
+import { type Transform as SucraseTransform, transform } from "sucrase"
 
 const TS_EXTENSIONS = new Set([".ts", ".tsx", ".mts", ".cts"])
 const JSX_EXTENSIONS = new Set([".tsx", ".jsx", ".ts"])
@@ -7,6 +7,82 @@ const TYPE_STAR_EXPORT_REGEX =
 
 const stripTypeStarExports = (code: string) =>
   code.replace(TYPE_STAR_EXPORT_REGEX, "")
+
+/**
+ * AI-generated TSX commonly wraps a block comment in braces between props.
+ * JSX parsers reject that syntax because the braces are only valid after the
+ * opening tag has closed. A plain block comment is valid in the same position.
+ *
+ * Each candidate is tried in isolation only after parsing fails. A candidate
+ * is used only if that one repair makes the entire file parse, so valid JSX
+ * child comments and comment-like text in strings remain unchanged.
+ */
+const getJsxCommentRepairCandidates = (code: string) => {
+  const candidates: string[] = []
+  const jsxCommentRegex = /\{\/\*[\s\S]*?\*\/\}/g
+
+  for (const match of code.matchAll(jsxCommentRegex)) {
+    const commentStart = match.index
+    const commentEnd = commentStart + match[0].length
+    const commentBody = match[0].slice(3, -3)
+    candidates.push(
+      `${code.slice(0, commentStart)}/* ${commentBody} */${code.slice(commentEnd)}`,
+    )
+  }
+
+  return candidates
+}
+
+type SucraseSyntaxError = Error & {
+  loc?: {
+    line?: number
+    column?: number
+  }
+}
+
+const getSyntaxErrorMessage = (error: Error) =>
+  error.message
+    .replace(/^Error transforming [^:]+:\s*/, "")
+    .replace(/\s*\(\d+:\d+\)$/, "")
+
+const createCodeFrame = (code: string, line: number, column: number) => {
+  const lines = code.split(/\r?\n/)
+  const firstLine = Math.max(1, line - 2)
+  const lastLine = Math.min(lines.length, line + 2)
+  const lineNumberWidth = String(lastLine).length
+  const frame: string[] = []
+
+  for (let lineNumber = firstLine; lineNumber <= lastLine; lineNumber++) {
+    const marker = lineNumber === line ? ">" : " "
+    frame.push(
+      `${marker} ${String(lineNumber).padStart(lineNumberWidth)} | ${lines[lineNumber - 1]}`,
+    )
+    if (lineNumber === line) {
+      frame.push(
+        `  ${" ".repeat(lineNumberWidth)} | ${" ".repeat(Math.max(0, column - 1))}^`,
+      )
+    }
+  }
+
+  return frame.join("\n")
+}
+
+const createHelpfulSyntaxError = (
+  error: SucraseSyntaxError,
+  code: string,
+  filePath: string,
+) => {
+  const line = error.loc?.line
+  const column = error.loc?.column
+
+  if (typeof line !== "number" || typeof column !== "number") {
+    return error
+  }
+
+  return new SyntaxError(
+    `Syntax error in "${filePath}" at ${line}:${column}: ${getSyntaxErrorMessage(error)}\n\n${createCodeFrame(code, line, column)}`,
+  )
+}
 
 const stripQueryAndHash = (filePath: string) => {
   const queryIndex = filePath.indexOf("?")
@@ -64,12 +140,30 @@ const getTransformsForFilePath = (filePath: string) => {
 export const transformWithSucrase = (code: string, filePath: string) => {
   const transforms = getTransformsForFilePath(filePath)
   const sanitizedCode = stripTypeStarExports(code)
-  const { code: transformedCode } = transform(sanitizedCode, {
-    filePath,
-    disableESTransforms: true,
-    production: true,
-    transforms,
-  })
 
-  return transformedCode
+  const transformCode = (codeToTransform: string) =>
+    transform(codeToTransform, {
+      filePath,
+      disableESTransforms: true,
+      production: true,
+      transforms,
+    }).code
+
+  try {
+    return transformCode(sanitizedCode)
+  } catch (error) {
+    if (!(error instanceof Error)) throw error
+
+    for (const repairCandidate of getJsxCommentRepairCandidates(
+      sanitizedCode,
+    )) {
+      try {
+        return transformCode(repairCandidate)
+      } catch {
+        // This comment was not the parse error. Try the next candidate.
+      }
+    }
+
+    throw createHelpfulSyntaxError(error, code, filePath)
+  }
 }

--- a/tests/examples/example09-not-defined-component.test.tsx
+++ b/tests/examples/example09-not-defined-component.test.tsx
@@ -1,5 +1,5 @@
-import { createCircuitWebWorker } from "lib/index"
 import { expect, test } from "bun:test"
+import { createCircuitWebWorker } from "lib/index"
 
 test("example9-not-defined-component", async () => {
   const circuitWebWorker = await createCircuitWebWorker({
@@ -17,7 +17,7 @@ test("example9-not-defined-component", async () => {
         );
       `)
   }).toThrowError(
-    `Eval compiled js error for \"entrypoint.tsx\": \"NotExportedComponent\" is not exported by \"@tsci/seveibar.a555timer\".\nIf \"NotExportedComponent\" is a type, use \"export type { NotExportedComponent }\" instead of \"export { NotExportedComponent }\"`,
+    `Error evaluating \"entrypoint.tsx\": \"NotExportedComponent\" is not exported by \"@tsci/seveibar.a555timer\".\nIf \"NotExportedComponent\" is a type, use \"export type { NotExportedComponent }\" instead of \"export { NotExportedComponent }\"`,
   )
 
   await circuitWebWorker.kill()

--- a/tests/repros/jsx-comment-between-props.test.tsx
+++ b/tests/repros/jsx-comment-between-props.test.tsx
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test"
+import { CircuitRunner } from "lib/runner/CircuitRunner"
+
+test("allows JSX-style comments between component props", async () => {
+  const runner = new CircuitRunner()
+
+  await runner.execute(`
+    export default () => {
+      const $pinNames = Array.from({ length: 28 }, (_, index) =>
+        "pin" + (index + 1),
+      )
+
+      return (
+        <chip
+          name="U1"
+          connections={$pinNames.map((name) => ({ [name]: name }))}
+          {/* Main controller — 28-pin SSOP */}
+          footprint="ssop28"
+          pinLabels={$pinNames}
+        />
+      )
+    }
+  `)
+})
+
+test("syntax errors include the source location and a code frame", async () => {
+  const runner = new CircuitRunner()
+
+  await expect(runner.execute("const value = ;")).rejects.toThrow(
+    `Syntax error in "entrypoint.tsx" at 1:15: Unexpected token\n\n> 1 | const value = ;\n    |               ^`,
+  )
+})


### PR DESCRIPTION
## What changed

- Retry TSX transforms by converting a single JSX-style block comment between component props into the equivalent valid block-comment syntax.
- Only accept a repair when that isolated change makes the entire file parse, preserving valid JSX child comments and comment-like string contents.
- Separate transform failures from runtime evaluation failures.
- Format remaining syntax errors with the source filename, line/column, surrounding source, and a caret.
- Rename the opaque `Eval compiled js error` runtime wrapper to `Error evaluating "<file>"`.

## Root cause

The reported circuit placed `{/* ... */}` between `<chip` props. That form is valid for JSX children but invalid inside an opening tag. Sucrase reported it as an unexpected token, and `importLocalFile` then caught the transform exception together with runtime exceptions and mislabeled it as a compiled-JS evaluation failure.

## User impact

The reported generated TSX now evaluates without requiring the user to rewrite unrelated constructs such as the anonymous default export, `Array.from` arrow callback, em-dash, or `$` identifier. Other syntax failures now point directly at source instead of presenting an opaque nested transform/eval message.

## Validation

- `bun test tests/repros/jsx-comment-between-props.test.tsx tests/examples/example09-not-defined-component.test.tsx`
- `bunx tsc --noEmit`
- `bun run format:check`
- `bun run build`
- Full suite exercised 147 passing tests before worker tests hit the checkout's initially missing build artifacts; after building, all affected worker/error tests passed on focused rerun.