### PR TITLE
Forward disabled flags from JSON config

### DIFF
--- a/lib/getPlatformConfig/getPlatformConfigForTscircuitConfig.ts
+++ b/lib/getPlatformConfig/getPlatformConfigForTscircuitConfig.ts
@@ -5,19 +5,26 @@ import { getPlatformConfig } from "./getPlatformConfig"
 interface TscircuitConfigWithPlatformConfig {
   platformConfig?: Partial<PlatformConfig>
   partsEngine?: PlatformConfig["partsEngine"]
+  pcbDisabled?: boolean
+  schematicDisabled?: boolean
 }
 
 export const getPlatformConfigForTscircuitConfig = (
   webWorkerConfiguration: WebWorkerConfiguration,
   config: TscircuitConfigWithPlatformConfig | null,
 ): PlatformConfig | undefined => {
-  const configPlatform = config?.platformConfig
-    ? config.platformConfig
-    : config?.partsEngine
-      ? { partsEngine: config.partsEngine }
-      : undefined
+  const configPlatform: Partial<PlatformConfig> = {
+    ...(typeof config?.pcbDisabled === "boolean"
+      ? { pcbDisabled: config.pcbDisabled }
+      : {}),
+    ...(typeof config?.schematicDisabled === "boolean"
+      ? { schematicDisabled: config.schematicDisabled }
+      : {}),
+    ...(config?.partsEngine ? { partsEngine: config.partsEngine } : {}),
+    ...config?.platformConfig,
+  }
 
-  if (!configPlatform) return undefined
+  if (Object.keys(configPlatform).length === 0) return undefined
 
   const mergedConfigPlatform = {
     ...webWorkerConfiguration.projectConfig,

--- a/lib/getPlatformConfig/getPlatformConfigForTscircuitConfig.ts
+++ b/lib/getPlatformConfig/getPlatformConfigForTscircuitConfig.ts
@@ -1,25 +1,22 @@
 import type { WebWorkerConfiguration } from "lib/shared/types"
-import type { PlatformConfig, ProjectConfig } from "@tscircuit/props"
+import type { PlatformConfig } from "@tscircuit/props"
 import { getPlatformConfig } from "./getPlatformConfig"
 
-interface TscircuitConfigWithPlatformConfig extends ProjectConfig {
+type TscircuitConfigWithPlatformConfig = Partial<PlatformConfig> & {
   platformConfig?: Partial<PlatformConfig>
-  partsEngine?: PlatformConfig["partsEngine"]
 }
 
 export const getPlatformConfigForTscircuitConfig = (
   webWorkerConfiguration: WebWorkerConfiguration,
   config: TscircuitConfigWithPlatformConfig | null,
 ): PlatformConfig | undefined => {
-  const pcbDisabled =
-    config && "pcbDisabled" in config ? config.pcbDisabled : undefined
-  const schematicDisabled =
-    config && "schematicDisabled" in config
-      ? config.schematicDisabled
-      : undefined
   const configPlatform: Partial<PlatformConfig> = {
-    ...(typeof pcbDisabled === "boolean" ? { pcbDisabled } : {}),
-    ...(typeof schematicDisabled === "boolean" ? { schematicDisabled } : {}),
+    ...(typeof config?.pcbDisabled === "boolean"
+      ? { pcbDisabled: config.pcbDisabled }
+      : {}),
+    ...(typeof config?.schematicDisabled === "boolean"
+      ? { schematicDisabled: config.schematicDisabled }
+      : {}),
     ...(config?.partsEngine ? { partsEngine: config.partsEngine } : {}),
     ...config?.platformConfig,
   }

--- a/lib/getPlatformConfig/getPlatformConfigForTscircuitConfig.ts
+++ b/lib/getPlatformConfig/getPlatformConfigForTscircuitConfig.ts
@@ -1,25 +1,25 @@
 import type { WebWorkerConfiguration } from "lib/shared/types"
-import type { PlatformConfig } from "@tscircuit/props"
+import type { PlatformConfig, ProjectConfig } from "@tscircuit/props"
 import { getPlatformConfig } from "./getPlatformConfig"
 
-interface TscircuitConfigWithPlatformConfig {
+interface TscircuitConfigWithPlatformConfig extends ProjectConfig {
   platformConfig?: Partial<PlatformConfig>
   partsEngine?: PlatformConfig["partsEngine"]
-  pcbDisabled?: boolean
-  schematicDisabled?: boolean
 }
 
 export const getPlatformConfigForTscircuitConfig = (
   webWorkerConfiguration: WebWorkerConfiguration,
   config: TscircuitConfigWithPlatformConfig | null,
 ): PlatformConfig | undefined => {
+  const pcbDisabled =
+    config && "pcbDisabled" in config ? config.pcbDisabled : undefined
+  const schematicDisabled =
+    config && "schematicDisabled" in config
+      ? config.schematicDisabled
+      : undefined
   const configPlatform: Partial<PlatformConfig> = {
-    ...(typeof config?.pcbDisabled === "boolean"
-      ? { pcbDisabled: config.pcbDisabled }
-      : {}),
-    ...(typeof config?.schematicDisabled === "boolean"
-      ? { schematicDisabled: config.schematicDisabled }
-      : {}),
+    ...(typeof pcbDisabled === "boolean" ? { pcbDisabled } : {}),
+    ...(typeof schematicDisabled === "boolean" ? { schematicDisabled } : {}),
     ...(config?.partsEngine ? { partsEngine: config.partsEngine } : {}),
     ...config?.platformConfig,
   }

--- a/lib/runner/loadTscircuitConfig.ts
+++ b/lib/runner/loadTscircuitConfig.ts
@@ -4,6 +4,7 @@ import type { WebWorkerConfiguration } from "lib/shared/types"
 import { getTsConfig } from "./tsconfigPaths"
 
 const TSCIRCUIT_CONFIG_PATHS = ["tscircuit.config.ts", "tscircuit.config.js"]
+const TSCIRCUIT_JSON_CONFIG_PATH = "tscircuit.config.json"
 
 interface LoadedTscircuitConfig {
   platformConfig?: Partial<PlatformConfig>
@@ -18,8 +19,17 @@ export const loadTscircuitConfig = async (
     debugNamespace?: string
   } = {},
 ): Promise<LoadedTscircuitConfig | null> => {
+  let jsonConfig: LoadedTscircuitConfig | null = null
+  if (TSCIRCUIT_JSON_CONFIG_PATH in fsMap) {
+    try {
+      jsonConfig = JSON.parse(fsMap[TSCIRCUIT_JSON_CONFIG_PATH])
+    } catch (error) {
+      console.warn("Failed to parse tscircuit.config.json:", error)
+    }
+  }
+
   const configPath = TSCIRCUIT_CONFIG_PATHS.find((path) => path in fsMap)
-  if (!configPath) return null
+  if (!configPath) return jsonConfig
 
   const ctx = createExecutionContext(webWorkerConfiguration, {
     platform: webWorkerConfiguration.platform,
@@ -34,5 +44,10 @@ export const loadTscircuitConfig = async (
   await importEvalPath(`./${configPath}`, ctx)
 
   const moduleExports = ctx.preSuppliedImports[configPath]
-  return moduleExports?.default ?? moduleExports ?? null
+  const moduleConfig = moduleExports?.default ?? moduleExports ?? null
+
+  return {
+    ...(jsonConfig ?? {}),
+    ...(moduleConfig ?? {}),
+  }
 }

--- a/lib/runner/loadTscircuitConfig.ts
+++ b/lib/runner/loadTscircuitConfig.ts
@@ -3,12 +3,14 @@ import { createExecutionContext, importEvalPath } from "lib/eval"
 import type { WebWorkerConfiguration } from "lib/shared/types"
 import { getTsConfig } from "./tsconfigPaths"
 
-const TSCIRCUIT_CONFIG_PATHS = ["tscircuit.config.ts", "tscircuit.config.js"]
-const TSCIRCUIT_JSON_CONFIG_PATH = "tscircuit.config.json"
+const TSCIRCUIT_CONFIG_PATHS = [
+  "tscircuit.config.ts",
+  "tscircuit.config.js",
+  "tscircuit.config.json",
+]
 
-interface LoadedTscircuitConfig {
+type LoadedTscircuitConfig = Partial<PlatformConfig> & {
   platformConfig?: Partial<PlatformConfig>
-  partsEngine?: PlatformConfig["partsEngine"]
   [key: string]: any
 }
 
@@ -19,16 +21,20 @@ export const loadTscircuitConfig = async (
     debugNamespace?: string
   } = {},
 ): Promise<LoadedTscircuitConfig | null> => {
+  const configPaths = TSCIRCUIT_CONFIG_PATHS.filter((path) => path in fsMap)
+  if (configPaths.length === 0) return null
+
   let jsonConfig: LoadedTscircuitConfig | null = null
-  if (TSCIRCUIT_JSON_CONFIG_PATH in fsMap) {
+  const jsonConfigPath = configPaths.find((path) => path.endsWith(".json"))
+  if (jsonConfigPath) {
     try {
-      jsonConfig = JSON.parse(fsMap[TSCIRCUIT_JSON_CONFIG_PATH])
+      jsonConfig = JSON.parse(fsMap[jsonConfigPath])
     } catch (error) {
       console.warn("Failed to parse tscircuit.config.json:", error)
     }
   }
 
-  const configPath = TSCIRCUIT_CONFIG_PATHS.find((path) => path in fsMap)
+  const configPath = configPaths.find((path) => !path.endsWith(".json"))
   if (!configPath) return jsonConfig
 
   const ctx = createExecutionContext(webWorkerConfiguration, {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@tscircuit/mm": "^0.0.9",
     "@tscircuit/ngspice-spice-engine": "^0.0.19",
     "@tscircuit/parts-engine": "^0.0.21",
-    "@tscircuit/props": "^0.0.587",
+    "@tscircuit/props": "^0.0.588",
     "@tscircuit/schematic-autolayout": "^0.0.6",
     "@tscircuit/schematic-match-adapt": "^0.0.18",
     "@tscircuit/schematic-trace-solver": "^0.0.104",

--- a/tests/features/platform-config.test.tsx
+++ b/tests/features/platform-config.test.tsx
@@ -21,3 +21,30 @@ test("platform configuration is forwarded to RootCircuit", async () => {
 
   await runner.kill()
 })
+
+test("disabled flags from tscircuit.config.json are forwarded to RootCircuit", async () => {
+  const runner = new CircuitRunner()
+
+  await runner.executeWithFsMap({
+    fsMap: {
+      "tscircuit.config.json": JSON.stringify({
+        mainEntrypoint: "example.tsx",
+        pcbDisabled: true,
+        schematicDisabled: true,
+      }),
+      "example.tsx": `
+        circuit.add(
+          <board width="10mm" height="10mm">
+            <resistor name="R1" resistance="1k" footprint="0402" />
+          </board>
+        )
+      `,
+    },
+  })
+
+  const circuit = (globalThis as any).__tscircuit_circuit
+  expect(circuit.platform?.pcbDisabled).toBe(true)
+  expect(circuit.platform?.schematicDisabled).toBe(true)
+
+  await runner.kill()
+})

--- a/tests/features/platform-config.test.tsx
+++ b/tests/features/platform-config.test.tsx
@@ -32,6 +32,13 @@ test("disabled flags from tscircuit.config.json are forwarded to RootCircuit", a
         pcbDisabled: true,
         schematicDisabled: true,
       }),
+      "tscircuit.config.ts": `
+        export default {
+          platformConfig: {
+            routingDisabled: true,
+          },
+        }
+      `,
       "example.tsx": `
         circuit.add(
           <board width="10mm" height="10mm">
@@ -45,6 +52,7 @@ test("disabled flags from tscircuit.config.json are forwarded to RootCircuit", a
   const circuit = (globalThis as any).__tscircuit_circuit
   expect(circuit.platform?.pcbDisabled).toBe(true)
   expect(circuit.platform?.schematicDisabled).toBe(true)
+  expect(circuit.platform?.routingDisabled).toBe(true)
 
   await runner.kill()
 })


### PR DESCRIPTION
## Summary

- load and merge `tscircuit.config.json` with optional TypeScript/JavaScript config
- include JSON in the shared `TSCIRCUIT_CONFIG_PATHS` discovery list
- forward top-level `pcbDisabled` and `schematicDisabled` values into the effective platform config
- use `Partial<PlatformConfig>` for the shared config fields instead of extending a separate config interface
- update `@tscircuit/props` to `^0.0.588`
- add regression coverage for JSON flags alongside a TypeScript `platformConfig`

## Why

`tscircuit.config.json` was previously used only to infer the entrypoint. Because it was not included in the runtime config passed to platform setup, its disabled flags never reached `RootCircuit`.

## Impact

Projects can now use `pcbDisabled` or `schematicDisabled` in `tscircuit.config.json` and have those settings applied consistently by both `CircuitRunner` and the web worker. JSON and module configuration continue to merge, with module `platformConfig` values retaining precedence.

## Validation

- `bun test tests/features/platform-config.test.tsx tests/features/parts-engine-platformConfig.test.ts`
- `bun test tests/examples/example17-parse-tscircuit-config.test.tsx`
- `bun run format:check`
- `bun run build`

The full test suite was previously attempted; an unrelated existing test (`should-hint-main-component-path-when-entrypoint-exports-component`) timed out at five seconds, after which the run was stopped.