### PR TITLE
Bump parts-engine to 0.0.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@tscircuit/miniflex": "^0.0.4",
     "@tscircuit/mm": "^0.0.9",
     "@tscircuit/ngspice-spice-engine": "^0.0.20",
-    "@tscircuit/parts-engine": "^0.0.21",
+    "@tscircuit/parts-engine": "^0.0.24",
     "@tscircuit/props": "^0.0.592",
     "@tscircuit/schematic-autolayout": "^0.0.6",
     "@tscircuit/schematic-match-adapt": "^0.0.18",


### PR DESCRIPTION
## Summary

Bump `@tscircuit/parts-engine` from `0.0.21` to `0.0.24`.

## Why

Parts-engine 0.0.24 includes EasyEDA 0.0.277, which preserves failed proxy HTTP statuses in propagated component-search errors. This allows downstream Circuit JSON warnings to retain `(HTTP 401)` instead of collapsing authentication failures into a status-less generic message.

## Validation

- temporary local integration test confirmed a mocked EasyEDA proxy 401 becomes a `source_part_not_found_warning` containing `Failed to search for the component (HTTP 401)`; the temporary test was removed before committing
- `bun test tests/features/parts-engine-platformConfig.test.ts tests/features/parts-engine-disabled.test.tsx` — 3 tests passed
- `bun run build`
- `bun run format:check`