### PR TITLE
Bump parts-engine to 0.0.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@tscircuit/miniflex": "^0.0.4",
     "@tscircuit/mm": "^0.0.9",
     "@tscircuit/ngspice-spice-engine": "^0.0.20",
-    "@tscircuit/parts-engine": "^0.0.24",
+    "@tscircuit/parts-engine": "^0.0.25",
     "@tscircuit/props": "^0.0.593",
     "@tscircuit/schematic-autolayout": "^0.0.6",
     "@tscircuit/schematic-match-adapt": "^0.0.18",


### PR DESCRIPTION
## What changed

- Bump `@tscircuit/parts-engine` from `^0.0.24` to `^0.0.25`.

## Why

parts-engine 0.0.25 preserves the EasyEDA proxy authentication `error_code` in its thrown error, allowing downstream consumers to distinguish `session_expired` from other HTTP 401 failures.

## Impact

No eval logic or public API changes. This only updates the packaged parts-engine implementation used by eval.

## Validation

- Focused parts-engine tests: 7 passed
- `bun run format:check`
- `bun run build`

The broad test suite separately encountered an existing five-second test timeout and then hung during cleanup.