### PR TITLE
Resolve directory index imports

### DIFF
--- a/lib/runner/resolveFilePath.ts
+++ b/lib/runner/resolveFilePath.ts
@@ -67,6 +67,15 @@ export const resolveFilePath = (
         return normalizedFilePathMap.get(possibleFilePath)!
       }
     }
+
+    // Match Node/TypeScript directory import behavior (e.g. "./section-solver"
+    // resolving to "./section-solver/index.ts").
+    for (const ext of FILE_EXTENSIONS) {
+      const possibleIndexPath = `${normalizedResolvedPath}/index.${ext}`
+      if (normalizedFilePathMap.has(possibleIndexPath)) {
+        return normalizedFilePathMap.get(possibleIndexPath)!
+      }
+    }
   }
 
   // Try resolving using tsconfig "paths" mapping when the import is non-relative
@@ -101,6 +110,12 @@ export const resolveFilePath = (
       const possibleFilePath = `${normalizedUnknownFilePath}.${ext}`
       if (normalizedFilePathMap.has(possibleFilePath)) {
         return normalizedFilePathMap.get(possibleFilePath)!
+      }
+    }
+    for (const ext of FILE_EXTENSIONS) {
+      const possibleIndexPath = `${normalizedUnknownFilePath}/index.${ext}`
+      if (normalizedFilePathMap.has(possibleIndexPath)) {
+        return normalizedFilePathMap.get(possibleIndexPath)!
       }
     }
   }

--- a/lib/runner/tsconfigPaths.ts
+++ b/lib/runner/tsconfigPaths.ts
@@ -62,6 +62,12 @@ export function resolveWithTsconfigPaths(opts: {
         return normalizedFilePathMap.get(withExt)!
       }
     }
+    for (const ext of extensions) {
+      const indexPath = `${normalizedCandidate}/index.${ext}`
+      if (normalizedFilePathMap.has(indexPath)) {
+        return normalizedFilePathMap.get(indexPath)!
+      }
+    }
     return null
   }
 
@@ -148,6 +154,13 @@ export function resolveWithBaseUrl(opts: {
     const withExt = `${normalizedFilePath}.${ext}`
     if (normalizedFilePathMap.has(withExt)) {
       return normalizedFilePathMap.get(withExt)!
+    }
+  }
+
+  for (const ext of extensions) {
+    const indexPath = `${normalizedFilePath}/index.${ext}`
+    if (normalizedFilePathMap.has(indexPath)) {
+      return normalizedFilePathMap.get(indexPath)!
     }
   }
 

--- a/tests/features/directory-index-imports.test.tsx
+++ b/tests/features/directory-index-imports.test.tsx
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test"
+import { runTscircuitCode } from "lib/runner"
+
+test("resolves a relative directory import to its index file", async () => {
+  const circuitJson = await runTscircuitCode(
+    {
+      "lib/component/index.tsx": `
+        export default () => <resistor name="R1" resistance="1k" />
+      `,
+      "user-code.tsx": `
+        import Component from "./lib/component"
+        export default () => <Component />
+      `,
+    },
+    { mainComponentPath: "user-code" },
+  )
+
+  expect(
+    circuitJson.find(
+      (element) => element.type === "source_component" && element.name === "R1",
+    ),
+  ).toBeDefined()
+})
+
+test("resolves a baseUrl directory import to its index file", async () => {
+  const circuitJson = await runTscircuitCode(
+    {
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: { baseUrl: "." },
+      }),
+      "lib/component/index.tsx": `
+        export default () => <resistor name="R1" resistance="1k" />
+      `,
+      "user-code.tsx": `
+        import Component from "lib/component"
+        export default () => <Component />
+      `,
+    },
+    { mainComponentPath: "user-code" },
+  )
+
+  expect(
+    circuitJson.find(
+      (element) => element.type === "source_component" && element.name === "R1",
+    ),
+  ).toBeDefined()
+})


### PR DESCRIPTION
## Summary

- resolve relative directory imports such as `./section-solver` through `index.ts`/`index.tsx`
- apply the same directory-index fallback to absolute/baseUrl and tsconfig-path candidates
- add regression coverage for relative and baseUrl directory imports

## Why

The browser evaluator could fetch every file in `tiny-hypergraph/lib/section-solver`, but failed on `import "./section-solver"` because resolution only tested the path itself and extension variants. Node/TypeScript-style directory imports need an `index.*` fallback.

This is the root cause of the clad1 RP2040 runtime error:

`Unresolved import "./section-solver" from directory "node_modules/tiny-hypergraph/lib"`

## Validation

- `bun test tests/features/directory-index-imports.test.tsx` (2 passing)
- `bun run build`