### PR TITLE
chore: bump @tscircuit/core to pull in format-si-unit fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "@tscircuit/image-utils": "^0.0.8",
     "@tscircuit/create-fdm-enclosure": "0.0.3",
     "@tsci/tscircuit.ti": "github:tscircuit/ti#57e314be4b2b06bc546d4def7453e619604d1157",
-    "@tscircuit/fanout-solver": "git+https://github.com/tscircuit/fanout-solver.git"
+    "@tscircuit/fanout-solver": "github:tscircuit/fanout-solver#34e4664"
   },
   "peerDependencies": {
     "typescript": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@tscircuit/circuit-json-util": "^0.0.101",
     "@tscircuit/common": "^0.0.20",
     "@tscircuit/copper-pour-solver": "0.0.42",
-    "@tscircuit/core": "^0.0.1536",
+    "@tscircuit/core": "^0.0.1537",
     "@tscircuit/footprinter": "^0.0.387",
     "@tscircuit/import-snippet": "^0.0.4",
     "@tscircuit/infer-cable-insertion-point": "^0.0.2",
@@ -136,7 +136,7 @@
     "@tscircuit/image-utils": "^0.0.8",
     "@tscircuit/create-fdm-enclosure": "0.0.3",
     "@tsci/tscircuit.ti": "github:tscircuit/ti#57e314be4b2b06bc546d4def7453e619604d1157",
-    "@tscircuit/fanout-solver": "github:tscircuit/fanout-solver#34e4664"
+    "@tscircuit/fanout-solver": "git+https://github.com/tscircuit/fanout-solver.git"
   },
   "peerDependencies": {
     "typescript": "^5.0.0",


### PR DESCRIPTION
Bumps `@tscircuit/core` to latest to automatically pull down the `format-si-unit` patch for parsing `10μH` components in docs/elements/inductor.
It shows 10H instead of 10μH