### PR TITLE
Use the npm-published fanout solver

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "@tscircuit/image-utils": "^0.0.8",
     "@tscircuit/create-fdm-enclosure": "0.0.3",
     "@tsci/tscircuit.ti": "github:tscircuit/ti#57e314be4b2b06bc546d4def7453e619604d1157",
-    "@tscircuit/fanout-solver": "0.0.10"
+    "@tscircuit/fanout-solver": "0.0.11"
   },
   "peerDependencies": {
     "typescript": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "@tscircuit/image-utils": "^0.0.8",
     "@tscircuit/create-fdm-enclosure": "0.0.3",
     "@tsci/tscircuit.ti": "github:tscircuit/ti#57e314be4b2b06bc546d4def7453e619604d1157",
-    "@tscircuit/fanout-solver": "0.0.11"
+    "@tscircuit/fanout-solver": "0.0.10"
   },
   "peerDependencies": {
     "typescript": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "@tscircuit/image-utils": "^0.0.8",
     "@tscircuit/create-fdm-enclosure": "0.0.3",
     "@tsci/tscircuit.ti": "github:tscircuit/ti#57e314be4b2b06bc546d4def7453e619604d1157",
-    "@tscircuit/fanout-solver": "github:tscircuit/fanout-solver#34e4664"
+    "@tscircuit/fanout-solver": "0.0.10"
   },
   "peerDependencies": {
     "typescript": "^5.0.0",


### PR DESCRIPTION
Replaces Eval's direct GitHub-pinned @tscircuit/fanout-solver dependency with its public npm release, 0.0.10. This prevents Eval's Core-update workflow from resolving Fanout Solver through GitHub before its dependency-sync step runs. Validated package.json syntax and git diff whitespace checks.