### PR TITLE
include target version in automated version bump PR titles

### DIFF
--- a/.github/workflows/bun-formatcheck.yml
+++ b/.github/workflows/bun-formatcheck.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   format-check:
     runs-on: ubuntu-latest
-    if: "${{ github.event_name != 'pull_request' || github.event.pull_request.title != 'chore: bump version' }}"
+    if: "${{ github.event_name != 'pull_request' || !startsWith(github.event.pull_request.title, 'chore: bump version') }}"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/bun-pver-release.yml
+++ b/.github/workflows/bun-pver-release.yml
@@ -35,12 +35,18 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}
 
+      - name: Get package version
+        id: package-version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@v5
         with:
           commit-message: "chore: bump version"
-          title: "chore: bump version"
+          title: "chore: bump version to v${{ steps.package-version.outputs.version }}"
           body: "Automated package update"
           branch: bump-version-${{ github.run_number }}
           base: main

--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -13,24 +13,22 @@ jobs:
     steps:
       - name: Check if should skip
         id: should-skip
+        if: startsWith(github.event.pull_request.title, env.SKIP_PR_TITLE)
         run: |
-          if [[ "${{ github.event.pull_request.title }}" == "${{ env.SKIP_PR_TITLE }}" ]]; then
-            echo "Skipping validation - this is a version bump PR"
-            exit 0
-          fi
+          echo "Skipping validation - this is a version bump PR"
 
       - name: Checkout code
-        if: github.event.pull_request.title != env.SKIP_PR_TITLE
+        if: ${{ !startsWith(github.event.pull_request.title, env.SKIP_PR_TITLE) }}
         uses: actions/checkout@v4
 
       - name: Setup bun
-        if: github.event.pull_request.title != env.SKIP_PR_TITLE
+        if: ${{ !startsWith(github.event.pull_request.title, env.SKIP_PR_TITLE) }}
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.1
 
       - name: Validate test matrix covers all directories
-        if: github.event.pull_request.title != env.SKIP_PR_TITLE
+        if: ${{ !startsWith(github.event.pull_request.title, env.SKIP_PR_TITLE) }}
         run: bun run scripts/validate-test-matrix.js
 
   test:
@@ -44,32 +42,30 @@ jobs:
     steps:
       - name: Check if should skip
         id: should-skip
+        if: startsWith(github.event.pull_request.title, env.SKIP_PR_TITLE)
         run: |
-          if [[ "${{ github.event.pull_request.title }}" == "${{ env.SKIP_PR_TITLE }}" ]]; then
-            echo "Skipping tests - this is a version bump PR"
-            exit 0
-          fi
+          echo "Skipping tests - this is a version bump PR"
 
       - name: Checkout code
-        if: github.event.pull_request.title != env.SKIP_PR_TITLE
+        if: ${{ !startsWith(github.event.pull_request.title, env.SKIP_PR_TITLE) }}
         uses: actions/checkout@v4
 
       - name: Setup bun
-        if: github.event.pull_request.title != env.SKIP_PR_TITLE
+        if: ${{ !startsWith(github.event.pull_request.title, env.SKIP_PR_TITLE) }}
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.1
 
       - name: Install dependencies
-        if: github.event.pull_request.title != env.SKIP_PR_TITLE
+        if: ${{ !startsWith(github.event.pull_request.title, env.SKIP_PR_TITLE) }}
         run: bun install
 
       - name: Build project
-        if: github.event.pull_request.title != env.SKIP_PR_TITLE
+        if: ${{ !startsWith(github.event.pull_request.title, env.SKIP_PR_TITLE) }}
         run: bun run build
 
       - name: Run tests for ${{ matrix.test-dir }}
-        if: github.event.pull_request.title != env.SKIP_PR_TITLE
+        if: ${{ !startsWith(github.event.pull_request.title, env.SKIP_PR_TITLE) }}
         run: |
           mapfile -t test_files < <(find tests/${{ matrix.test-dir }} -type f \( -name "*.test.ts" -o -name "*.test.tsx" \) | sort)
           if [ ${#test_files[@]} -eq 0 ]; then

--- a/.github/workflows/bun-typecheck.yml
+++ b/.github/workflows/bun-typecheck.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   type-check:
     runs-on: ubuntu-latest
-    if: "${{ github.event_name != 'pull_request' || github.event.pull_request.title != 'chore: bump version' }}"
+    if: "${{ github.event_name != 'pull_request' || !startsWith(github.event.pull_request.title, 'chore: bump version') }}"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
-    if: "${{ github.event_name != 'pull_request' || github.event.pull_request.title != 'chore: bump version' }}"
+    if: "${{ github.event_name != 'pull_request' || !startsWith(github.event.pull_request.title, 'chore: bump version') }}"
     steps:
       - uses: actions/checkout@v4
       


### PR DESCRIPTION
## Summary

- Read the updated package version after `pver release`
- Include the target version in automated PR titles
- Update CI skip conditions to support version-specific titles

## Example

Before:

`chore: bump version`

After:

`chore: bump version to v0.0.1090`

## Validation

- Validated all modified workflow YAML files
- Verified package version extraction from `package.json`