### PR TITLE
Add browser directory import bug repro

### DIFF
--- a/tests/repros/directory-import-index.test.tsx
+++ b/tests/repros/directory-import-index.test.tsx
@@ -1,38 +1,41 @@
 import { expect, test } from "bun:test"
 import { createCircuitWebWorker } from "lib"
 
-test("browser evaluator resolves directory imports to index.tsx", async () => {
-  const circuitWebWorker = await createCircuitWebWorker({
-    webWorkerUrl: new URL("../../webworker/entrypoint.ts", import.meta.url),
-  })
+test.failing(
+  "browser evaluator resolves directory imports to index.tsx",
+  async () => {
+    const circuitWebWorker = await createCircuitWebWorker({
+      webWorkerUrl: new URL("../../webworker/entrypoint.ts", import.meta.url),
+    })
 
-  try {
-    await circuitWebWorker.executeWithFsMap({
-      entrypoint: "entrypoint.tsx",
-      fsMap: {
-        "entrypoint.tsx": `
+    try {
+      await circuitWebWorker.executeWithFsMap({
+        entrypoint: "entrypoint.tsx",
+        fsMap: {
+          "entrypoint.tsx": `
           import { Part } from "./imports"
 
           circuit.add(<Part />)
         `,
-        "imports/index.tsx": `
+          "imports/index.tsx": `
           export const Part = () => (
             <resistor name="R1" resistance="1k" footprint="0402" />
           )
         `,
-      },
-    })
+        },
+      })
 
-    await circuitWebWorker.renderUntilSettled()
+      await circuitWebWorker.renderUntilSettled()
 
-    const circuitJson = await circuitWebWorker.getCircuitJson()
-    expect(
-      circuitJson.some(
-        (element: any) =>
-          element.type === "source_component" && element.name === "R1",
-      ),
-    ).toBe(true)
-  } finally {
-    await circuitWebWorker.kill()
-  }
-})
+      const circuitJson = await circuitWebWorker.getCircuitJson()
+      expect(
+        circuitJson.some(
+          (element: any) =>
+            element.type === "source_component" && element.name === "R1",
+        ),
+      ).toBe(true)
+    } finally {
+      await circuitWebWorker.kill()
+    }
+  },
+)

--- a/tests/repros/directory-import-index.test.tsx
+++ b/tests/repros/directory-import-index.test.tsx
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test"
+import { createCircuitWebWorker } from "lib"
+
+test("browser evaluator resolves directory imports to index.tsx", async () => {
+  const circuitWebWorker = await createCircuitWebWorker({
+    webWorkerUrl: new URL("../../webworker/entrypoint.ts", import.meta.url),
+  })
+
+  try {
+    await circuitWebWorker.executeWithFsMap({
+      entrypoint: "entrypoint.tsx",
+      fsMap: {
+        "entrypoint.tsx": `
+          import { Part } from "./imports"
+
+          circuit.add(<Part />)
+        `,
+        "imports/index.tsx": `
+          export const Part = () => (
+            <resistor name="R1" resistance="1k" footprint="0402" />
+          )
+        `,
+      },
+    })
+
+    await circuitWebWorker.renderUntilSettled()
+
+    const circuitJson = await circuitWebWorker.getCircuitJson()
+    expect(
+      circuitJson.some(
+        (element: any) =>
+          element.type === "source_component" && element.name === "R1",
+      ),
+    ).toBe(true)
+  } finally {
+    await circuitWebWorker.kill()
+  }
+})


### PR DESCRIPTION
## Summary

Adds a focused browser-worker repro for a virtual filesystem directory import:

```ts
import { Part } from "./imports"
```

The only matching module is `imports/index.tsx`. Node-style and common TypeScript tooling resolve this automatically, but the evaluator currently reports the import as unresolved.

The repro uses `test.failing`, allowing CI to pass while the bug exists. Once directory-index resolution is implemented, Bun will report the unexpected pass so the marker can be removed.

## Impact

AI-generated tscircuit projects frequently use directory imports. This repro captures the desired evaluator behavior so a follow-up resolver change can support those projects without requiring explicit `./imports/index` paths.

## Validation

- `bun test tests/repros/directory-import-index.test.tsx` passes with the known failure marker.
- `bun run format:check` passes.
- `git diff --check` passes.