### PR TITLE
Resolve directory imports to index files

### DIFF
--- a/lib/runner/resolveFilePath.ts
+++ b/lib/runner/resolveFilePath.ts
@@ -35,7 +35,10 @@ const resolveNormalizedFilePath = (
     candidatePaths.push(`${normalizedPath}.${ext}`)
   }
 
-  const directoryPath = normalizedPath.replace(/\/+$/, "")
+  let directoryPath = normalizedPath
+  while (directoryPath.endsWith("/")) {
+    directoryPath = directoryPath.slice(0, -1)
+  }
   if (directoryPath) {
     for (const ext of FILE_EXTENSIONS) {
       candidatePaths.push(`${directoryPath}/index.${ext}`)

--- a/lib/runner/resolveFilePath.ts
+++ b/lib/runner/resolveFilePath.ts
@@ -20,6 +20,11 @@ const FILE_EXTENSIONS = [
   "stp",
 ]
 
+/**
+ * Resolves a normalized path against the virtual filesystem, preferring an
+ * exact file, then an extension match, and finally a directory index file.
+ * Returns the original filesystem path so callers preserve its casing.
+ */
 const resolveNormalizedFilePath = (
   normalizedPath: string,
   normalizedFilePathMap: Map<string, string>,

--- a/lib/runner/resolveFilePath.ts
+++ b/lib/runner/resolveFilePath.ts
@@ -20,6 +20,30 @@ const FILE_EXTENSIONS = [
   "stp",
 ]
 
+const resolveNormalizedFilePath = (
+  normalizedPath: string,
+  normalizedFilePathMap: Map<string, string>,
+) => {
+  const exactMatch = normalizedFilePathMap.get(normalizedPath)
+  if (exactMatch) return exactMatch
+
+  for (const ext of FILE_EXTENSIONS) {
+    const fileMatch = normalizedFilePathMap.get(`${normalizedPath}.${ext}`)
+    if (fileMatch) return fileMatch
+  }
+
+  const directoryPath = normalizedPath.replace(/\/+$/, "")
+  for (const ext of FILE_EXTENSIONS) {
+    const indexPath = directoryPath
+      ? `${directoryPath}/index.${ext}`
+      : `index.${ext}`
+    const indexMatch = normalizedFilePathMap.get(indexPath)
+    if (indexMatch) return indexMatch
+  }
+
+  return null
+}
+
 export const resolveFilePath = (
   unknownFilePath: string,
   fsMapOrAllFilePaths: Record<string, string> | string[],
@@ -56,17 +80,11 @@ export const resolveFilePath = (
 
   // When baseUrl is set, non-relative imports should go through baseUrl resolution
   if (isRelativeImport || !hasBaseUrl) {
-    if (normalizedFilePathMap.has(normalizedResolvedPath)) {
-      return normalizedFilePathMap.get(normalizedResolvedPath)!
-    }
-
-    // Search for file with a set of different extensions
-    for (const ext of FILE_EXTENSIONS) {
-      const possibleFilePath = `${normalizedResolvedPath}.${ext}`
-      if (normalizedFilePathMap.has(possibleFilePath)) {
-        return normalizedFilePathMap.get(possibleFilePath)!
-      }
-    }
+    const resolvedFilePath = resolveNormalizedFilePath(
+      normalizedResolvedPath,
+      normalizedFilePathMap,
+    )
+    if (resolvedFilePath) return resolvedFilePath
   }
 
   // Try resolving using tsconfig "paths" mapping when the import is non-relative
@@ -94,15 +112,10 @@ export const resolveFilePath = (
   // When baseUrl is set, imports should resolve via baseUrl or fail, not fall back to absolute paths
   if (!isRelativeImport && !hasBaseUrl) {
     const normalizedUnknownFilePath = normalizeFilePath(unknownFilePath)
-    if (normalizedFilePathMap.has(normalizedUnknownFilePath)) {
-      return normalizedFilePathMap.get(normalizedUnknownFilePath)!
-    }
-    for (const ext of FILE_EXTENSIONS) {
-      const possibleFilePath = `${normalizedUnknownFilePath}.${ext}`
-      if (normalizedFilePathMap.has(possibleFilePath)) {
-        return normalizedFilePathMap.get(possibleFilePath)!
-      }
-    }
+    return resolveNormalizedFilePath(
+      normalizedUnknownFilePath,
+      normalizedFilePathMap,
+    )
   }
 
   return null

--- a/lib/runner/resolveFilePath.ts
+++ b/lib/runner/resolveFilePath.ts
@@ -24,21 +24,22 @@ const resolveNormalizedFilePath = (
   normalizedPath: string,
   normalizedFilePathMap: Map<string, string>,
 ) => {
-  const exactMatch = normalizedFilePathMap.get(normalizedPath)
-  if (exactMatch) return exactMatch
+  const candidatePaths = [normalizedPath]
 
   for (const ext of FILE_EXTENSIONS) {
-    const fileMatch = normalizedFilePathMap.get(`${normalizedPath}.${ext}`)
-    if (fileMatch) return fileMatch
+    candidatePaths.push(`${normalizedPath}.${ext}`)
   }
 
   const directoryPath = normalizedPath.replace(/\/+$/, "")
-  for (const ext of FILE_EXTENSIONS) {
-    const indexPath = directoryPath
-      ? `${directoryPath}/index.${ext}`
-      : `index.${ext}`
-    const indexMatch = normalizedFilePathMap.get(indexPath)
-    if (indexMatch) return indexMatch
+  if (directoryPath) {
+    for (const ext of FILE_EXTENSIONS) {
+      candidatePaths.push(`${directoryPath}/index.${ext}`)
+    }
+  }
+
+  for (const candidatePath of candidatePaths) {
+    const resolvedPath = normalizedFilePathMap.get(candidatePath)
+    if (resolvedPath) return resolvedPath
   }
 
   return null

--- a/tests/repros/directory-import-index.test.tsx
+++ b/tests/repros/directory-import-index.test.tsx
@@ -1,41 +1,38 @@
 import { expect, test } from "bun:test"
 import { createCircuitWebWorker } from "lib"
 
-test.failing(
-  "browser evaluator resolves directory imports to index.tsx",
-  async () => {
-    const circuitWebWorker = await createCircuitWebWorker({
-      webWorkerUrl: new URL("../../webworker/entrypoint.ts", import.meta.url),
-    })
+test("browser evaluator resolves directory imports to index.tsx", async () => {
+  const circuitWebWorker = await createCircuitWebWorker({
+    webWorkerUrl: new URL("../../webworker/entrypoint.ts", import.meta.url),
+  })
 
-    try {
-      await circuitWebWorker.executeWithFsMap({
-        entrypoint: "entrypoint.tsx",
-        fsMap: {
-          "entrypoint.tsx": `
+  try {
+    await circuitWebWorker.executeWithFsMap({
+      entrypoint: "entrypoint.tsx",
+      fsMap: {
+        "entrypoint.tsx": `
           import { Part } from "./imports"
 
           circuit.add(<Part />)
         `,
-          "imports/index.tsx": `
+        "imports/index.tsx": `
           export const Part = () => (
             <resistor name="R1" resistance="1k" footprint="0402" />
           )
         `,
-        },
-      })
+      },
+    })
 
-      await circuitWebWorker.renderUntilSettled()
+    await circuitWebWorker.renderUntilSettled()
 
-      const circuitJson = await circuitWebWorker.getCircuitJson()
-      expect(
-        circuitJson.some(
-          (element: any) =>
-            element.type === "source_component" && element.name === "R1",
-        ),
-      ).toBe(true)
-    } finally {
-      await circuitWebWorker.kill()
-    }
-  },
-)
+    const circuitJson = await circuitWebWorker.getCircuitJson()
+    expect(
+      circuitJson.some(
+        (element: any) =>
+          element.type === "source_component" && element.name === "R1",
+      ),
+    ).toBe(true)
+  } finally {
+    await circuitWebWorker.kill()
+  }
+})


### PR DESCRIPTION
## Summary

- resolve virtual filesystem directory imports through `index.*` files
- preserve exact-file and extension-based resolution precedence
- convert the browser-worker repro from `test.failing` into a passing regression test

## Root cause

`resolveFilePath` checked exact paths and extension-appended paths, but never tried an `index.*` file inside the requested directory. As a result, imports such as `./imports` failed when the module existed only at `imports/index.tsx`.

## Impact

Browser-worker projects can now use standard directory imports without spelling out `/index`, matching common Node.js and TypeScript resolution behavior.

## Validation

- `bun test tests/repros/directory-import-index.test.tsx tests/features/parent-directory-import.test.tsx tests/node-resolution` (15 passed, 2 skipped)
- `bun run format:check`
- `bun run build`
- `git diff --check`

Follow-up to #3743.