### PR TITLE
fix: update parts engine for C11337 enrichment

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@tscircuit/miniflex": "^0.0.4",
     "@tscircuit/mm": "^0.0.9",
     "@tscircuit/ngspice-spice-engine": "^0.0.20",
-    "@tscircuit/parts-engine": "^0.0.25",
+    "@tscircuit/parts-engine": "^0.0.28",
     "@tscircuit/props": "^0.0.620",
     "@tscircuit/schematic-autolayout": "^0.0.6",
     "@tscircuit/schematic-match-adapt": "^0.0.18",

--- a/tests/repros/c11337-supplier-enrichment-font-style.test.tsx
+++ b/tests/repros/c11337-supplier-enrichment-font-style.test.tsx
@@ -117,9 +117,7 @@ test("C11337 supplier enrichment preserves an explicit SOT-23-5 footprint", asyn
         "OUT",
       ],
       "smtPadCount": 5,
-      "supplierWarningMessages": [
-        "Failed to fetch supplier footprint for <chip#N name=\".U_LDO\" /> (jlcpcb:C11337): [ { \"received\": \" \", \"code\": \"invalid_enum_value\", \"options\": [ \"normal\", \"italic\" ], \"path\": [ \"fontStyle\" ], \"message\": \"Invalid enum value. Expected 'normal' | 'italic', received ' '\" } ]",
-      ],
+      "supplierWarningMessages": [],
     }
   `)
 


### PR DESCRIPTION
## Fix

Child of #3866. `@tscircuit/eval` still resolved `@tscircuit/parts-engine` 0.0.25, whose bundled EasyEDA parser rejects C11337 whitespace-only `fontStyle`. This updates the dependency floor to the already-published 0.0.28 release containing the parser fix.

## Snapshot diff

The parent snapshot records the exact `invalid_enum_value` warning while preserving the visual five-pad SOT-23-5 snapshot and IN/GND/EN/NC/OUT mapping. This child changes the same inline snapshot to an empty warning list; the visual footprint snapshot is unchanged.

## Validation

- `bun test tests/features/jlcpcb-footprint-library-map.test.tsx tests/features/jlcpcb-footprint-library-map-cadmodel.test.tsx tests/repros/c11337-supplier-enrichment-font-style.test.tsx`
- `bunx tsc --noEmit`
- `bun run format:check`
- `bun run build`
- live public C11337 fetch through eval default engine: 23 Circuit JSON elements, 5 SMT pads

Stack: #3866 → this PR.