### PR TITLE
Preserve platform defaults when eval receives partial overrides

### DIFF
--- a/lib/eval/execution-context.ts
+++ b/lib/eval/execution-context.ts
@@ -41,14 +41,9 @@ export function createExecutionContext(
 ): ExecutionContext {
   globalThis.React = React
 
-  const basePlatform =
-    opts.platform ||
-    getPlatformConfig(
-      {},
-      {
-        easyEdaProxyConfig: webWorkerConfiguration.easyEdaProxyConfig,
-      },
-    )
+  const basePlatform = getPlatformConfig(opts.platform, {
+    easyEdaProxyConfig: webWorkerConfiguration.easyEdaProxyConfig,
+  })
   const platform = opts.projectConfig
     ? { ...basePlatform, ...opts.projectConfig }
     : basePlatform

--- a/lib/getPlatformConfig/getPlatformConfig.ts
+++ b/lib/getPlatformConfig/getPlatformConfig.ts
@@ -123,6 +123,7 @@ export const getPlatformConfig = (
   }
 
   return {
+    ...overrides,
     localCacheEngine: overrides.localCacheEngine,
     partsEngine: partsEngine as PartsEngine,
     autorouterMap: {
@@ -167,6 +168,7 @@ export const getPlatformConfig = (
           return ngspiceEngineCache.simulate(spice)
         },
       },
+      ...overrides.spiceEngineMap,
     },
     footprintLibraryMap: {
       kicad: async (footprintName: string) => {
@@ -228,6 +230,7 @@ export const getPlatformConfig = (
           ),
         }
       },
+      ...overrides.footprintLibraryMap,
     },
     footprintFileParserMap: {
       kicad_mod: {
@@ -244,6 +247,7 @@ export const getPlatformConfig = (
           }
         },
       },
+      ...overrides.footprintFileParserMap,
     },
     staticFileLoaderMap: {
       kicad_pcb: loadKicadPcbStaticFile,

--- a/tests/features/platform-config.test.tsx
+++ b/tests/features/platform-config.test.tsx
@@ -21,3 +21,22 @@ test("platform configuration is forwarded to RootCircuit", async () => {
 
   await runner.kill()
 })
+
+test("partial platform configuration preserves default footprint libraries", async () => {
+  const runner = new CircuitRunner({
+    platform: {
+      localCacheEngine: {
+        getItem: () => null,
+        setItem: () => {},
+      },
+    },
+  })
+
+  await runner.execute(`circuit.add(<board width="10mm" height="10mm" />)`)
+
+  const circuit = (globalThis as any).__tscircuit_circuit
+  expect(typeof circuit.platform?.footprintLibraryMap?.kicad).toBe("function")
+  expect(typeof circuit.platform?.footprintLibraryMap?.jlcpcb).toBe("function")
+
+  await runner.kill()
+})


### PR DESCRIPTION
## Summary

- merge partial runtime platform overrides with eval's built-in platform defaults
- preserve custom autorouter, SPICE, footprint-library, footprint-parser, and static-file-loader entries
- add a regression test for the cache-only platform config supplied by `tsci dev`

## Root cause

RunFrame for the CLI supplies a partial `platformConfig` containing its local cache engine. `createExecutionContext` treated any supplied platform object as a complete platform configuration, so eval skipped `getPlatformConfig()` and dropped `footprintLibraryMap.kicad`. Consequently, `kicad:*` footprints worked in the web editor but failed in `tsci dev` with “No footprint resolver is configured for library \"kicad\".”

## Impact

CLI users retain CLI-specific platform overrides while receiving the same built-in KiCad and JLCPCB footprint resolvers as web users.

## Validation

- `bun test tests/features/platform-config.test.tsx tests/features/project-config.test.tsx tests/features/parts-engine-disabled.test.tsx tests/features/static-file-loader-map.test.tsx tests/repros/platform-config-not-being-overriden.test.tsx` (10 passed)
- `bunx tsc --noEmit`
- `bun run format:check`
- `bun run build`
- Full `bun test` was attempted; Bun 1.3.2 exited with signal 11 while starting `tests/features/circuit-event-forwarding.test.tsx`, after the preceding tests passed.