### PR TITLE
Update Bun test runner to 1.3.14

### DIFF
--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -27,7 +27,7 @@ jobs:
         if: github.event.pull_request.title != env.SKIP_PR_TITLE
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.1
+          bun-version: 1.3.14
 
       - name: Validate test matrix covers all directories
         if: github.event.pull_request.title != env.SKIP_PR_TITLE
@@ -58,7 +58,7 @@ jobs:
         if: github.event.pull_request.title != env.SKIP_PR_TITLE
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.1
+          bun-version: 1.3.14
 
       - name: Install dependencies
         if: github.event.pull_request.title != env.SKIP_PR_TITLE


### PR DESCRIPTION
## Summary

- update both Bun test workflow jobs from Bun 1.3.1 to Bun 1.3.14
- keep the matrix-validation and test jobs on the same Bun release

## Why

Bun 1.3.14 is the current official stable release. Updating the pinned test runner brings CI onto the latest fixes and runtime behavior while leaving workflows that already use `latest` unchanged.

## Validation

- `bun run test:validate-matrix`
- `bun run format:check`
- `git diff --check`