### PR TITLE
Bump parts-engine to 0.0.29

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@tscircuit/miniflex": "^0.0.4",
     "@tscircuit/mm": "^0.0.9",
     "@tscircuit/ngspice-spice-engine": "^0.0.20",
-    "@tscircuit/parts-engine": "^0.0.28",
+    "@tscircuit/parts-engine": "^0.0.29",
     "@tscircuit/props": "^0.0.622",
     "@tscircuit/schematic-autolayout": "^0.0.6",
     "@tscircuit/schematic-match-adapt": "^0.0.18",


### PR DESCRIPTION
## Summary

- bump `@tscircuit/parts-engine` from `^0.0.28` to `^0.0.29`
- bring JST `standard="jst_*"` supplier selection into eval's bundled parts engine

## Why

Eval bundles `@tscircuit/parts-engine` into its library and webworker outputs. Because caret ranges for `0.0.x` do not cross patch versions, `^0.0.28` cannot resolve the newly published `0.0.29` release.

Without this bump, JST connectors receive no supplier footprint or CAD model through the default eval platform config.

## Validation

- `bun test tests/examples/example16-parts-engine.test.tsx tests/features/parts-engine-cache.test.tsx`
- `bunx tsc --noEmit`
- `bun run format:check`
- `bun run build`
- live `runTscircuitCode` integration with `<connector standard="jst_ph" pinCount={2} />`: selected `C131337`, produced two plated holes, and included an EasyEDA CAD model