### PR TITLE
Resolve versioned CDN imports from pre-supplied modules

### DIFF
--- a/lib/eval/import-eval-path.ts
+++ b/lib/eval/import-eval-path.ts
@@ -17,6 +17,7 @@ import { isDistDirEmpty } from "./isDistDirEmpty"
 import { resolveEntrypointPath } from "./resolveEntrypointPath"
 import { resolveRelativePath } from "lib/utils/resolveRelativePath"
 import { hasPreSuppliedImport } from "./pre-supplied-imports"
+import { parseNpmSpecifier } from "lib/utils/npm-cdn-urls"
 
 const debug = Debug("tsci:eval:import-eval-path")
 
@@ -76,6 +77,11 @@ const getNpmPackageSpecifierFromCdnImport = (importName: string) => {
     version && version !== "latest" ? `${packageName}@${version}` : packageName
 
   return filePath ? `${packageSpecifier}/${filePath}` : packageSpecifier
+}
+
+const getUnversionedNpmSpecifier = (importName: string) => {
+  const { packageName, filePath } = parseNpmSpecifier(importName)
+  return filePath ? `${packageName}/${filePath}` : packageName
 }
 
 export async function importEvalPath(
@@ -154,6 +160,20 @@ export async function importEvalPath(
 
   const cdnNpmPackageSpecifier = getNpmPackageSpecifierFromCdnImport(importName)
   if (cdnNpmPackageSpecifier) {
+    const unversionedSpecifier = getUnversionedNpmSpecifier(
+      cdnNpmPackageSpecifier,
+    )
+
+    if (hasPreSuppliedImport(preSuppliedImports, unversionedSpecifier)) {
+      const preSuppliedImport = preSuppliedImports[unversionedSpecifier]
+      preSuppliedImports[cdnNpmPackageSpecifier] = preSuppliedImport
+      preSuppliedImports[importName] = preSuppliedImport
+      ctx.logger.info(
+        `Import "${importName}" resolved from preSuppliedImports as "${unversionedSpecifier}"`,
+      )
+      return
+    }
+
     if (disableCdnLoading) {
       throw new Error(
         `Cannot find module "${cdnNpmPackageSpecifier}". The package is not available in the local environment.\n\n${ctx.logger.stringifyLogs()}`,

--- a/lib/utils/npm-cdn-urls.ts
+++ b/lib/utils/npm-cdn-urls.ts
@@ -17,7 +17,7 @@ export function getJscdnPackageUrl(importName: string): string {
   return `${JSCDN_ORIGIN}/${pathParts.join("/")}`
 }
 
-function parseNpmSpecifier(importName: string): ParsedNpmSpecifier {
+export function parseNpmSpecifier(importName: string): ParsedNpmSpecifier {
   const pathParts = importName.split("/")
 
   if (importName.startsWith("@")) {

--- a/tests/util-fns/import-npm-package-from-cdn.test.ts
+++ b/tests/util-fns/import-npm-package-from-cdn.test.ts
@@ -133,6 +133,56 @@ test("resolves jsdelivr relative /npm imports while evaluating cdn package code"
   )
 })
 
+test("resolves versioned CDN imports from pre-supplied package subpaths", async () => {
+  const requestedUrls: string[] = []
+  const ctx = createTestExecutionContext()
+  const reactJsxRuntime = {
+    jsx: "pre-supplied-jsx",
+    jsxs: "pre-supplied-jsxs",
+  }
+  ctx.preSuppliedImports["react/jsx-runtime"] = reactJsxRuntime
+
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = input.toString()
+    requestedUrls.push(url)
+
+    if (url.startsWith("https://jscdn.tscircuit.com/")) {
+      return new Response("not found", {
+        status: 404,
+        statusText: "Not Found",
+      })
+    }
+
+    if (url === "https://cdn.jsdelivr.net/npm/example-package/+esm") {
+      return new Response(
+        'import { jsx } from "/npm/react@19.2.8/jsx-runtime/+esm"; export const loadedValue = jsx',
+        {
+          status: 200,
+          headers: { "content-type": "application/javascript" },
+        },
+      )
+    }
+
+    return new Response("not found", {
+      status: 404,
+      statusText: "Not Found",
+    })
+  }) as typeof fetch
+
+  await importNpmPackageFromCdn({ importName: "example-package" }, ctx)
+
+  expect(requestedUrls).toEqual([
+    "https://jscdn.tscircuit.com/example-package/latest/+esm",
+    "https://cdn.jsdelivr.net/npm/example-package/+esm",
+  ])
+  expect(ctx.preSuppliedImports["example-package"].loadedValue).toBe(
+    "pre-supplied-jsx",
+  )
+  expect(ctx.preSuppliedImports["/npm/react@19.2.8/jsx-runtime/+esm"]).toBe(
+    reactJsxRuntime,
+  )
+})
+
 test("resolves full jscdn url imports while evaluating cdn package code", async () => {
   const requestedUrls: string[] = []
   const ctx = createTestExecutionContext()


### PR DESCRIPTION
## What changed

- Canonicalize versioned npm CDN specifiers before fetching nested dependencies.
- Reuse matching pre-supplied modules and subpaths, including `react/jsx-runtime`.
- Alias both the CDN import and versioned package specifier to the built-in module.
- Add a regression test for `/npm/react@19.2.8/jsx-runtime/+esm`.

## Why

RunFrame's evaluator received versioned absolute imports from CDN bundles after its existing pre-supplied import check. That caused React's JSX runtime to be fetched and re-evaluated instead of using the runtime already bundled with eval, producing missing generated JSX export errors for packages such as `biscuitboard`.

## Impact

Browser-evaluated npm packages can import versioned CDN forms of built-in modules without loading a second copy or depending on CDN wrapper export behavior.

## Related

- Complements tscircuit/jscdn.tscircuit.com#12, which preserves named exports when a CDN load is still required.

## Validation

- `bun test tests/util-fns/import-npm-package-from-cdn.test.ts`
- `bunx tsc --noEmit`
- `bun run format:check`
- `bun run build`
- Worker tests that require the built distribution
- Loaded the published `biscuitboard` package through the patched evaluator and rendered a circuit successfully