### PR TITLE
chore: update parts-engine to 0.0.31 for connector CAD sizing fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@tscircuit/miniflex": "^0.0.4",
     "@tscircuit/mm": "^0.0.9",
     "@tscircuit/ngspice-spice-engine": "^0.0.20",
-    "@tscircuit/parts-engine": "^0.0.29",
+    "@tscircuit/parts-engine": "^0.0.31",
     "@tscircuit/props": "^0.0.646",
     "@tscircuit/schematic-autolayout": "^0.0.6",
     "@tscircuit/schematic-match-adapt": "^0.0.18",


### PR DESCRIPTION
Eval's default platform config uses Parts Engine to resolve and convert JLCPCB components. This raises `@tscircuit/parts-engine` from `^0.0.29` to `^0.0.31`, ensuring the minimum accepted release includes EasyEDA 0.0.350 and its CAD model sizing fix.

The fix was delivered through https://github.com/tscircuit/parts-engine/pull/51 and https://github.com/tscircuit/easyeda-converter/pull/540. The converter previously mixed PCB footprint dimensions with an SVG height when setting `cad_component.size`. For C165948, this constrained the USB-C body to incorrect bounds and made it render too small relative to its footprint. With model bounds available, the converter now emits the model's own dimensions: **8.94 × 7.90 × 4.101 mm**.

Eval explicitly bundles Parts Engine into its library, runner, webworker, and platform-config outputs. Updating EasyEDA in RunFrame or CLI alone does not replace the Parts Engine code in an already-built Eval release. Raising this dependency makes the corrected converter part of subsequent Eval builds, which downstream consumers must then adopt. This PR does not deploy the connector docs itself.

Only `package.json` changes; this repository does not track a lockfile.

Validation:
- Parts Engine/platform-config and JLCPCB footprint integration tests: **9 passed, 0 failed** across 5 files.
- `bunx tsc --noEmit`: passed.
- `bun run build:platform-config`: passed, including declaration generation.
- Called the default `getPlatformConfig().partsEngine.fetchPartCircuitJson` for C165948 and asserted the returned CAD dimensions are **8.94 × 7.90 × 4.101 mm**.
- `git diff --check`: passed.
